### PR TITLE
migrate from CairoSVG to svglib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,11 @@ numpy>=1.25.2
 scipy>=1.11.1
 #tox==4.9.0
 pyyaml==6.0.1
-cairosvg==2.7.0
+#cairosvg==2.7.0
+pycairo
+renderlab
+rlPyCairo
+svglib
 ocp_vscode==2.0.13
 GitPython==3.1.40
 progress==1.6

--- a/src/partcad/shape.py
+++ b/src/partcad/shape.py
@@ -9,7 +9,10 @@
 import cadquery as cq
 import build123d as b3d
 
-import cairosvg
+#import cairosvg
+from svglib.svglib import svg2rlg
+from reportlab.graphics import renderPM
+
 import logging
 import tempfile
 
@@ -140,12 +143,20 @@ class Shape:
         logging.info("Rendering: %s" % filepath)
         svg_path = self._get_svg_path()
 
-        cairosvg.svg2png(
-            url=svg_path,
-            write_to=filepath,
-            output_width=width,
-            output_height=height,
-        )
+        # cairosvg.svg2png(
+        #     url=svg_path,
+        #     write_to=filepath,
+        #     output_width=width,
+        #     output_height=height,
+        # )
+
+        #NO SCALING POSSIBLE
+        #could install pymupdf and convert to PDF
+        #and convert that to PNG with scaling
+        drawing = svg2rlg(svg_path)
+        renderPM.drawToFile(drawing, 
+                            filepath, 
+                            fmt="PNG")
 
     def render_txt(self, filepath=None):
         if filepath is None:


### PR DESCRIPTION
This is an untested prototype, but just submitting for consideration. One regression is that this method does not support setting the PNG output size. It is possible to re-add the functionality by performing an intermediate conversion from SVG -> PDF with renderlab, and PDF -> PNG with pymupdf which does support scaling. This could be done with BytesIO to prevent creating an actual file on disk.