### PR TITLE
 fix: add install jaraco.functools and suppress pip wheel warnings

### DIFF
--- a/.github/actions/setup-all/action.yml
+++ b/.github/actions/setup-all/action.yml
@@ -127,7 +127,7 @@ runs:
         mamba activate ${{ env.ENV_PATH }}
         python -m ensurepip --upgrade
         python -m pip install --upgrade pip
-        python -m pip install --upgrade wheel mypy setuptools
+        python -m pip install --upgrade wheel mypy setuptools jaraco.functools
         # Install all core and a subset of CLI dependencies, that are required for tests
         python -m pip install --upgrade ./partcad
         python -m pip install --upgrade -r partcad/requirements-dev.in

--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04]
-        python-version: ["3.10"]
+        python-version: ["3.12"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -33,7 +33,8 @@ jobs:
             libtiff5-dev libjpeg-dev libopenjp2-7-dev zlib1g-dev \
             libfreetype6-dev liblcms2-dev libwebp-dev tcl8.6-dev tk8.6-dev \
             python3-tk libharfbuzz-dev libfribidi-dev libxcb1-dev
-
+      - name: install dependencies
+        run: pip install --upgrade attrs
       - working-directory: partcad-ide-vscode
         run: python -m pip install nox
       - working-directory: partcad-ide-vscode

--- a/partcad-ide-vscode/noxfile.py
+++ b/partcad-ide-vscode/noxfile.py
@@ -84,6 +84,14 @@ def _update_npm_packages(session: nox.Session) -> None:
     session.run("npm", "install", external=True)
 
 
+def _install_pip_version(session):
+    """
+    Installing a specific pip version compatible with pip-tools.
+    TODO(azhar): Remove this when pip-tools is updated to support pip 25.1+.
+    """
+    session.install("pip<25.1")
+
+
 def _setup_template_environment(session: nox.Session) -> None:
     session.install("wheel", "pip-tools")
     session.run("pip-compile", "--generate-hashes", "--resolver=backtracking", "--upgrade", "./requirements.in")
@@ -100,6 +108,7 @@ def _setup_template_environment(session: nox.Session) -> None:
 @nox.session()
 def setup(session: nox.Session) -> None:
     """Sets up the template for development."""
+    _install_pip_version(session)
     _setup_template_environment(session)
 
 

--- a/partcad-ide-vscode/noxfile.py
+++ b/partcad-ide-vscode/noxfile.py
@@ -93,6 +93,7 @@ def _install_pip_version(session):
 
 
 def _setup_template_environment(session: nox.Session) -> None:
+    _install_pip_version(session)
     session.install("wheel", "pip-tools")
     session.run("pip-compile", "--generate-hashes", "--resolver=backtracking", "--upgrade", "./requirements.in")
     session.run(
@@ -108,7 +109,6 @@ def _setup_template_environment(session: nox.Session) -> None:
 @nox.session()
 def setup(session: nox.Session) -> None:
     """Sets up the template for development."""
-    _install_pip_version(session)
     _setup_template_environment(session)
 
 

--- a/partcad/src/partcad/runtime.py
+++ b/partcad/src/partcad/runtime.py
@@ -268,7 +268,22 @@ class Runtime:
         # if stdout:
         #     pc_logging.debug("Output of %s: %s" % (cmd, stdout))
         if stderr:
-            pc_logging.error("Error in %s: %s" % (cmd, stderr))
+            # TODO(azhar): remove this when the issue is fixed
+            keywords = [
+                "DEPRECATION: Wheel filename",
+                "Invalid wheel filename (invalid version):",
+                "pip 25.3 will enforce this behaviour change.",
+            ]
+
+            stderr_lines = [
+                line.strip()
+                for line in stderr.splitlines()
+                if line.strip() and not any(keyword in line for keyword in keywords)
+            ]
+
+            if stderr_lines:
+                stderr = "\n".join(stderr_lines)
+                pc_logging.error("Error in %s: %s" % (cmd, stderr))
 
         # TODO(clairbee): remove the below when a better troubleshooting mechanism is introduced
         # f = open("/tmp/log", "w")


### PR DESCRIPTION
- Added python -m pip install --upgrade jaraco.functools to fix ImportError during htmlmin setup.py execution to fix CD Build
- Filtered out DEPRECATION warnings for invalid wheel filenames to fix CI Behave


- DEPRECATION: Wheel filename 'casadi-3.1.0p1-cp27-cp27m-manylinux1_x86_64.whl' is not correctly normalised. Future versions of pip will raise the following error:
- Invalid wheel filename (invalid version): 'casadi-3.1.0p1-cp27-cp27m-manylinux1_x86_64'
        
- pip 25.3 will enforce this behaviour change. A possible replacement is to rename the wheel to use a correctly normalised name (this may require updating the version in the project metadata). Discussion can be found at https://github.com/pypa/pip/issues/12938

## Copilot Summary

<!-- Use GitHub Copilot to generate a summary of your changes here. -->
