### PR TITLE
fix(ci): make conda env setup survive corrupted package downloads

### DIFF
--- a/.github/actions/setup-all/action.yml
+++ b/.github/actions/setup-all/action.yml
@@ -120,10 +120,15 @@ runs:
         . ~/.bashrc || true
         . ~/.bash_profile || true
         set -e
+        . .github/actions/setup-all/mamba-create-retry.sh
+        # On Windows CONDA is a native path (C:\...) that bash cannot use as-is.
+        conda_root="${CONDA:-$HOME/miniconda3}"
+        if command -v cygpath >/dev/null 2>&1; then
+          conda_root="$(cygpath -u "${conda_root}")"
+        fi
         # Sometimes in GitHub workflows, the test environment is not created from the first attempt due to networking issues
-        if ! mamba env list | awk '{print $1}' | grep -qx test; then
-          rm -rf "${CONDA:-$HOME/miniconda3}/envs/test"
-          bash .github/actions/setup-all/mamba-create-retry.sh -n test
+        if [ ! -d "${conda_root}/envs/test" ]; then
+          mamba_create_retry -n test
         fi
         mamba init
 
@@ -136,7 +141,8 @@ runs:
       run: |
         . ~/.bashrc
         . ~/.bash_profile
-        bash .github/actions/setup-all/mamba-create-retry.sh -n ${{ env.ENV_PATH }} python=${{ matrix.python-version }} poetry
+        . .github/actions/setup-all/mamba-create-retry.sh
+        mamba_create_retry -n ${{ env.ENV_PATH }} python=${{ matrix.python-version }} poetry
         mamba activate ${{ env.ENV_PATH }}
         python -m ensurepip --upgrade
         python -m pip install --upgrade pip

--- a/.github/actions/setup-all/action.yml
+++ b/.github/actions/setup-all/action.yml
@@ -109,14 +109,23 @@ runs:
 
     - name: Init conda
       if: ${{ inputs.preheat_only != 'true' || steps.conda_cache.outputs.cache-hit != 'true' || steps.python_cache.outputs.cache-hit != 'true' }}
-      shell: bash -el {0}
+      # No '-e' here on purpose. The shell profiles auto-activate the 'test'
+      # environment, so when the step above did not manage to create it, that
+      # activation fails. Under '-e' it aborted this step before the recovery
+      # below could run, which is exactly when the recovery is needed.
+      shell: bash -l {0}
       run: |
         [[ -f ~/.bashrc ]] || touch ~/.bashrc
         [[ -f ~/.bash_profile ]] || touch ~/.bash_profile
-        . ~/.bashrc
-        . ~/.bash_profile
+        . ~/.bashrc || true
+        . ~/.bash_profile || true
+        set -e
         # Sometimes in GitHub workflows, the test environment is not created from the first attempt due to networking issues
-        mamba init || (rm -rf ~/miniconda3/envs/test && mamba create -y -n test && mamba init)
+        if ! mamba env list | awk '{print $1}' | grep -qx test; then
+          rm -rf "${CONDA:-$HOME/miniconda3}/envs/test"
+          bash .github/actions/setup-all/mamba-create-retry.sh -n test
+        fi
+        mamba init
 
     # Install dev dependencies
     - name: install dev dependencies
@@ -127,7 +136,7 @@ runs:
       run: |
         . ~/.bashrc
         . ~/.bash_profile
-        mamba create -y -n ${{ env.ENV_PATH }} python=${{ matrix.python-version }} poetry
+        bash .github/actions/setup-all/mamba-create-retry.sh -n ${{ env.ENV_PATH }} python=${{ matrix.python-version }} poetry
         mamba activate ${{ env.ENV_PATH }}
         python -m ensurepip --upgrade
         python -m pip install --upgrade pip

--- a/.github/actions/setup-all/mamba-create-retry.sh
+++ b/.github/actions/setup-all/mamba-create-retry.sh
@@ -1,27 +1,34 @@
 #!/usr/bin/env bash
 #
-# Create a conda environment, retrying transient package corruption.
+# Defines mamba_create_retry: create a conda environment, retrying transient
+# package corruption.
 #
 # conda-forge downloads intermittently land corrupted and mamba aborts the whole
 # job with "Found incorrect download: <pkg>" / "<pkg>.tar.bz2 extraction
 # failed". The upstream packages are fine on a refetch, so drop the cached
 # tarballs and try again rather than losing the run to a bad download.
 #
-# Usage: mamba-create-retry.sh -n <env> [packages...]
-set -euo pipefail
+# Source this file rather than executing it: 'mamba' is a shell function set up
+# by 'conda init', and a child shell would not inherit it (which on Windows
+# leaves no working mamba at all).
+#
+# Usage: . mamba-create-retry.sh && mamba_create_retry -n <env> [packages...]
 
-attempts="${MAMBA_CREATE_ATTEMPTS:-3}"
+mamba_create_retry() {
+  local attempts="${MAMBA_CREATE_ATTEMPTS:-3}"
+  local attempt
 
-for attempt in $(seq 1 "${attempts}"); do
-  if mamba create -y "$@"; then
-    exit 0
-  fi
+  for attempt in $(seq 1 "${attempts}"); do
+    if mamba create -y "$@"; then
+      return 0
+    fi
 
-  if [ "${attempt}" -ge "${attempts}" ]; then
-    echo "mamba create failed after ${attempts} attempt(s): $*" >&2
-    exit 1
-  fi
+    if [ "${attempt}" -ge "${attempts}" ]; then
+      echo "mamba create failed after ${attempts} attempt(s): $*" >&2
+      return 1
+    fi
 
-  echo "mamba create failed (attempt ${attempt}/${attempts}); cleaning package cache and retrying" >&2
-  mamba clean --packages --tarballs -y || true
-done
+    echo "mamba create failed (attempt ${attempt}/${attempts}); cleaning package cache and retrying" >&2
+    mamba clean --packages --tarballs -y || true
+  done
+}

--- a/.github/actions/setup-all/mamba-create-retry.sh
+++ b/.github/actions/setup-all/mamba-create-retry.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Create a conda environment, retrying transient package corruption.
+#
+# conda-forge downloads intermittently land corrupted and mamba aborts the whole
+# job with "Found incorrect download: <pkg>" / "<pkg>.tar.bz2 extraction
+# failed". The upstream packages are fine on a refetch, so drop the cached
+# tarballs and try again rather than losing the run to a bad download.
+#
+# Usage: mamba-create-retry.sh -n <env> [packages...]
+set -euo pipefail
+
+attempts="${MAMBA_CREATE_ATTEMPTS:-3}"
+
+for attempt in $(seq 1 "${attempts}"); do
+  if mamba create -y "$@"; then
+    exit 0
+  fi
+
+  if [ "${attempt}" -ge "${attempts}" ]; then
+    echo "mamba create failed after ${attempts} attempt(s): $*" >&2
+    exit 1
+  fi
+
+  echo "mamba create failed (attempt ${attempt}/${attempts}); cleaning package cache and retrying" >&2
+  mamba clean --packages --tarballs -y || true
+done


### PR DESCRIPTION
## Problem

conda-forge downloads intermittently land corrupted, and mamba aborts the whole job with `Found incorrect download: <pkg>` / `<pkg>.tar.bz2 extraction failed`.

This is not isolated. Within a ~30 minute window it hit four jobs across three different packages, on `devel` as well as on open PRs:

| Job | Package | Step |
|---|---|---|
| `nox` → build (ubuntu-24.04, 3.12) on **devel** | `pycparser` | install dev dependencies |
| Examples (PartCAD) (ubuntu-latest, 3.11) | `_openmp_mutex` | setup-miniconda |
| Pytest (VS Code extension) (ubuntu-latest, 3.11) | `expat` | setup-miniconda |

Two separate problems compounded a transient fetch into a lost run.

**1. The existing recovery was unreachable.**

`setup-miniconda` runs with `continue-on-error: true`, so its failure to create the `test` environment was swallowed. The next step then ran under `bash -el`, whose profiles auto-activate `test`. With the environment missing, that activation failed and `-e` aborted the step *before* its own recovery line could run:

```bash
. ~/.bashrc          # <- aborts here when 'test' does not exist
. ~/.bash_profile
mamba init || (rm -rf ~/miniconda3/envs/test && mamba create -y -n test && mamba init)   # never reached
```

The logs confirm it — the only output was `EnvironmentNameNotFound`, with none of the step's own commands producing any. The recovery was dead code exactly when it was needed.

**2. Environment creation had no retry**, so a single bad download lost the run. This is what took down `devel`'s own `nox` job, in a step the recovery above does not cover.

## Fix

- Drop `-e` for `Init conda` and tolerate the profile sourcing, so the recovery is reachable; restore `set -e` immediately afterwards so real failures still fail the step.
- Gate the recreate on an explicit environment-existence check rather than on `mamba init`'s exit code, which is not a reliable proxy for "the env exists".
- Route both environment creations through a shared `mamba-create-retry.sh`, which drops the cached tarballs and retries (3 attempts) before giving up.
- Use `$CONDA` instead of a hardcoded `~/miniconda3`, since this action also runs on macOS and Windows.

## Verification

Verified locally:

- A reproduction confirms `bash -el` never reaches the recovery, while `bash -l` does.
- `set -e` after the sourcing still fails the step on a genuine error.
- The retry script behaves correctly for success, transient-then-recover, and permanent-failure, and does not waste a clean after the final attempt.
- Env detection does not false-positive on the `env-test-<job>-<version>` environments that co-exist at runtime (`grep -qx`).
- `Validate GitHub Actions` and `shellcheck` pass via pre-commit.

**Not verified:** the CI path itself. Only a real run exercises it, and the retry branch only proves out when corruption actually recurs. The happy path is unchanged in behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
