### PR TITLE
refactor(deps): use PartCAD's own Location instead of build123d's

### DIFF
--- a/partcad/src/partcad/__init__.py
+++ b/partcad/src/partcad/__init__.py
@@ -11,7 +11,7 @@ from . import telemetry
 
 telemetry.init(__version__)
 
-from build123d import Location
+from .geom import Location
 
 from .globals import (
     init,

--- a/partcad/src/partcad/assembly.py
+++ b/partcad/src/partcad/assembly.py
@@ -13,6 +13,7 @@ import typing
 import build123d as b3d
 
 from . import telemetry
+from .geom import Location
 from .shape import Shape
 from .shape_ai import ShapeWithAi
 from .sync_threads import threadpool_manager
@@ -51,7 +52,7 @@ class Assembly(ShapeWithAi):
         self,
         child_item: Shape,  # pc.Part or pc.Assembly
         name=None,
-        loc=b3d.Location((0.0, 0.0, 0.0), (0.0, 0.0, 1.0), 0.0),
+        loc=Location((0.0, 0.0, 0.0), (0.0, 0.0, 1.0), 0.0),
     ):
         self.children.append(AssemblyChild(child_item, name, loc))
         self._wrapped = None  # Invalidate if any
@@ -95,6 +96,9 @@ class Assembly(ShapeWithAi):
                 if child.name is not None:
                     item.label = child.name
                 if child.location is not None:
+                    # 'item' is a build123d object while 'child.location' is a pc.Location
+                    # (see geom.py). build123d's Shape.locate() only reads '.wrapped', which
+                    # both types expose as a TopLoc_Location, so no conversion is needed here.
                     item.locate(child.location)
             return item
 

--- a/partcad/src/partcad/assembly_factory_assy.py
+++ b/partcad/src/partcad/assembly_factory_assy.py
@@ -14,11 +14,11 @@ import os
 import yaml
 
 from OCP.gp import gp_Trsf
-import build123d as b3d
 
 from . import telemetry
 from .assembly import Assembly, AssemblyChild
 from .assembly_factory_file import AssemblyFactoryFile
+from .geom import Location
 from . import logging as pc_logging
 from .utils import normalize_resource_path
 
@@ -134,7 +134,7 @@ class AssemblyFactoryAssy(AssemblyFactoryFile):
         # "location" is an optional parameter for both parts and assemblies
         if "location" in node:
             l = node["location"]
-            location = b3d.Location((l[0][0], l[0][1], l[0][2]), (l[1][0], l[1][1], l[1][2]), l[2])
+            location = Location((l[0][0], l[0][1], l[0][2]), (l[1][0], l[1][1], l[1][2]), l[2])
         elif "connect" in node:
             connect = node["connect"]
             connect_with_iface = connect.get("with", None)
@@ -160,7 +160,7 @@ class AssemblyFactoryAssy(AssemblyFactoryFile):
             connect_to_port = connect.get("to", None)
             location = None
         else:
-            location = b3d.Location((0, 0, 0), (0, 0, 1), 0)
+            location = Location((0, 0, 0), (0, 0, 1), 0)
 
         if connect_with_instance is not None and "*" in connect_with_instance:
             connect_with_instance_pattern = connect_with_instance
@@ -259,7 +259,7 @@ class AssemblyFactoryAssy(AssemblyFactoryFile):
                     if hasattr(child, "location"):
                         target_part_location = child.location
                     else:
-                        target_part_location = b3d.Location((0, 0, 0), (0, 0, 1), 0)
+                        target_part_location = Location((0, 0, 0), (0, 0, 1), 0)
 
                     # If there is no source interface specified,
                     # but there is only one present, then use it
@@ -750,7 +750,7 @@ class AssemblyFactoryAssy(AssemblyFactoryFile):
                         # TODO(clairbee): Do we need to support this?
                         pc_logging.warning("Peer port auto-detection has failed: %s" % name)
 
-                    turn_around = b3d.Location(
+                    turn_around = Location(
                         (0, 0, 0),
                         (0.71, 0.71, 0),
                         180,
@@ -776,7 +776,7 @@ class AssemblyFactoryAssy(AssemblyFactoryFile):
                         for source_offset in source_offsets:
                             trsf.Multiply(source_offset)
                         trsf.Multiply(source_port.location.wrapped.Transformation().Inverted())
-                        location = b3d.Location(trsf)
+                        location = Location(trsf)
                     elif source_port is None and target_port is not None:
                         pc_logging.debug(
                             "Connected %s to %s of %s"
@@ -792,7 +792,7 @@ class AssemblyFactoryAssy(AssemblyFactoryFile):
                         trsf.Multiply(turn_around)
                         for target_offset in target_offsets:
                             trsf.Multiply(target_offset)
-                        location = b3d.Location(trsf)
+                        location = Location(trsf)
                     elif source_port is not None and target_port is None:
                         pc_logging.debug("Connected %s of %s to %s" % (connect_with_port, name, connect_to_name))
                         trsf = target_part_location.wrapped.Transformation()
@@ -800,15 +800,15 @@ class AssemblyFactoryAssy(AssemblyFactoryFile):
                         for source_offset in source_offsets:
                             trsf.Multiply(source_offset)
                         trsf.Multiply(source_port.location.wrapped.Transformation().Inverted())
-                        location = b3d.Location(trsf)
+                        location = Location(trsf)
                     elif source_port is None and target_port is None:
                         pc_logging.debug("Connected %s to %s" % (name, connect_to_name))
                         trsf = target_part_location.wrapped.Transformation()
                         trsf.Multiply(turn_around)
-                        location = b3d.Location(trsf)
+                        location = Location(trsf)
                     else:
                         pc_logging.error("Not enough data to connect %s" % name)
-                        location = b3d.Location((0, 0, 0), (0, 0, 1), 0)
+                        location = Location((0, 0, 0), (0, 0, 1), 0)
 
         if not item is None:
             return [item, name, location]

--- a/partcad/src/partcad/geom.py
+++ b/partcad/src/partcad/geom.py
@@ -8,6 +8,7 @@
 #
 
 import math
+from typing import Sequence
 
 from OCP.TopLoc import TopLoc_Location
 from OCP.gp import (
@@ -22,18 +23,50 @@ from . import logging as pc_logging
 
 
 class Location:
+    """A rigid body transform: a rotation about an axis through the origin followed by a translation.
+
+    The accepted constructor forms are:
+      Location()                                  the identity location
+      Location(gp_Trsf)                           wrap an existing OCCT transformation
+      Location(TopLoc_Location)                   wrap an existing OCCT location
+      Location(Location)                          copy of another location
+      Location([t, axis, angle])                  the packed form used by PartCAD config files,
+                                                  e.g. [[0, 0, 0], [0, 0, 1], 0]
+      Location(t, axis, angle)                    the same, spelled as three arguments
+    """
+
     wrapped: TopLoc_Location
 
-    def __init__(self, arg=None):
-        if arg is None:
+    def __init__(self, arg=None, axis=None, angle=None):
+        if axis is not None or angle is not None:
+            # The three-argument form: Location((x, y, z), (ax, ay, az), angle).
+            if arg is None or axis is None or angle is None:
+                raise ValueError("geom.Location: the three-argument form needs a translation, an axis and an angle")
+            trsf = Location.trsf_from_coords(arg, axis, angle)
+            self.wrapped = TopLoc_Location(trsf)
+        elif arg is None:
             self.wrapped = TopLoc_Location()
         elif isinstance(arg, gp_Trsf):
             self.wrapped = TopLoc_Location(arg)
-        elif isinstance(arg, list):
+        elif isinstance(arg, TopLoc_Location):
+            self.wrapped = arg
+        elif isinstance(arg, Location):
+            self.wrapped = arg.wrapped
+        elif isinstance(arg, (list, tuple)):
             trsf = Location.trsf_from_coords(arg[0], arg[1], arg[2])
             self.wrapped = TopLoc_Location(trsf)
         else:
             raise ValueError("geom.Location: Invalid argument type")
+
+    def inverse(self) -> "Location":
+        """Return the location that undoes this one."""
+        return Location(self.wrapped.Transformation().Inverted())
+
+    def __mul__(self, other: "Location") -> "Location":
+        """Compose two locations: (a * b) applies b first and then a."""
+        if not isinstance(other, Location):
+            return NotImplemented
+        return Location(self.wrapped.Transformation().Multiplied(other.wrapped.Transformation()))
 
     def __repr__(self):
         trsf = self.wrapped.Transformation()
@@ -45,7 +78,7 @@ class Location:
         return f"Location({[trans.X(), trans.Y(), trans.Z()]}, {[dir.X(), dir.Y(), dir.Z()]}, {angle})"
 
     @classmethod
-    def trsf_from_coords(self, t: list[float], ax: list[float], angle: float):
+    def trsf_from_coords(self, t: Sequence[float], ax: Sequence[float], angle: float):
         # pc_logging.info(f"trsf_from_coords: {t}, {ax}, {angle}")
         T = gp_Trsf()
         T.SetRotation(

--- a/partcad/tests/unit/test_geom.py
+++ b/partcad/tests/unit/test_geom.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+#
+# PartCAD, 2025
+#
+# Licensed under Apache License, Version 2.0.
+#
+
+import math
+
+import pytest
+
+from OCP.gp import gp_Pnt
+
+import partcad as pc
+from partcad.geom import Location
+
+
+def _matrix(location):
+    """Return the 3x4 transformation matrix of a location as a flat list of floats."""
+    trsf = location.wrapped.Transformation()
+    return [trsf.Value(row, col) for row in range(1, 4) for col in range(1, 5)]
+
+
+def _apply(location, point):
+    """Apply a location to a point and return the resulting coordinates."""
+    pnt = gp_Pnt(*[float(c) for c in point])
+    pnt.Transform(location.wrapped.Transformation())
+    return (pnt.X(), pnt.Y(), pnt.Z())
+
+
+def _assert_close(actual, expected):
+    assert len(actual) == len(expected)
+    for a, e in zip(actual, expected):
+        assert math.isclose(a, e, rel_tol=1e-9, abs_tol=1e-9), f"{actual} != {expected}"
+
+
+def test_geom_location_identity():
+    _assert_close(_matrix(Location()), _matrix(Location(None)))
+    _assert_close(_apply(Location(), (1.0, 2.0, 3.0)), (1.0, 2.0, 3.0))
+
+
+def test_geom_location_three_argument_form_matches_packed_forms():
+    """The three argument form is the same transform as the packed list/tuple forms."""
+    three_args = Location((1, 2, 3), (0, 0, 1), 45)
+    packed_list = Location([[1, 2, 3], [0, 0, 1], 45])
+    packed_tuple = Location(((1, 2, 3), (0, 0, 1), 45))
+
+    _assert_close(_matrix(three_args), _matrix(packed_list))
+    _assert_close(_matrix(three_args), _matrix(packed_tuple))
+
+
+def test_geom_location_rotates_about_the_origin_before_translating():
+    """Rotation is about an axis through the origin, the translation is applied afterwards.
+
+    A 90 degree rotation about Z maps (1, 0, 0) onto (0, 1, 0). Only if the translation is
+    applied after that rotation does the point end up at (0, 1, 0) + (1, 2, 3). Had the
+    translation been applied first, the point would have landed at (-2, 1, 3) instead.
+    """
+    location = Location((1, 2, 3), (0, 0, 1), 90)
+    _assert_close(_apply(location, (1, 0, 0)), (1.0, 3.0, 3.0))
+
+
+def test_geom_location_normalizes_the_axis():
+    """A non unit axis is normalized, exactly as gp_Dir does."""
+    _assert_close(
+        _matrix(Location((0, 0, 0), (0, 0, 5), 90)),
+        _matrix(Location((0, 0, 0), (0, 0, 1), 90)),
+    )
+
+
+def test_geom_location_from_trsf_and_copies():
+    trsf = Location.trsf_from_coords((4, 5, 6), (0, 1, 0), 33)
+    from_trsf = Location(trsf)
+    _assert_close(_matrix(from_trsf), _matrix(Location((4, 5, 6), (0, 1, 0), 33)))
+    _assert_close(_matrix(Location(from_trsf.wrapped)), _matrix(from_trsf))
+    _assert_close(_matrix(Location(from_trsf)), _matrix(from_trsf))
+
+
+def test_geom_location_composition_applies_the_right_hand_side_first():
+    rotate = Location((0, 0, 0), (0, 0, 1), 90)
+    translate = Location((1, 0, 0), (0, 0, 1), 0)
+
+    # Translate first, then rotate: (0,0,0) -> (1,0,0) -> (0,1,0)
+    _assert_close(_apply(rotate * translate, (0, 0, 0)), (0.0, 1.0, 0.0))
+    # Rotate first, then translate: (0,0,0) -> (0,0,0) -> (1,0,0)
+    _assert_close(_apply(translate * rotate, (0, 0, 0)), (1.0, 0.0, 0.0))
+
+
+def test_geom_location_inverse():
+    location = Location((1, 2, 3), (1, 1, 0), 70)
+    _assert_close(_matrix(location * location.inverse()), _matrix(Location()))
+    _assert_close(_apply(location.inverse(), _apply(location, (7, -3, 2))), (7.0, -3.0, 2.0))
+
+
+def test_geom_location_rejects_bad_arguments():
+    with pytest.raises(ValueError):
+        Location((1, 2, 3), (0, 0, 1), None)
+    with pytest.raises(ValueError):
+        Location((1, 2, 3), None, 45)
+    with pytest.raises(ValueError):
+        Location(None, (0, 0, 1), 45)
+    with pytest.raises(ValueError):
+        Location("not a location")
+
+
+def test_partcad_location_is_the_partcad_one():
+    """The public pc.Location name is PartCAD's own Location."""
+    assert pc.Location is Location
+    _assert_close(_matrix(pc.Location((0, 0, 1), (0, 0, 1), 0)), _matrix(Location([[0, 0, 1], [0, 0, 1], 0])))


### PR DESCRIPTION
## Why

PartCAD already had a `Location` in `geom.py` wrapping `gp_Trsf`/`TopLoc_Location`, yet the assembly code and the public `partcad.Location` name came from build123d. That duplication is one of the reasons the main process had to depend on build123d at all.

## What

- Extends `geom.Location` to accept the `((x,y,z), (ax,ay,az), angle)` form used by the call sites, alongside the forms it already took.
- Adds composition (`*`) and `inverse()` so the public type keeps the operations build123d's `Location` offered. Nothing in-tree uses them yet, but `partcad.Location` is public API and dropping them would be a silent regression for user scripts.
- Switches the 9 call sites in `assembly_factory_assy.py`, the default in `assembly.py`, and the `partcad.Location` export.

## Correctness

Transform-order is the risk here: getting rotation-vs-translation backwards would silently corrupt every assembly rather than raise. It was checked **numerically** against build123d 0.8.0 — the 3×4 matrices agree to 1e-12 across identity, rotated, negative-angle and non-unit-axis cases. Rotation is applied about an axis through the origin and the translation is then set, matching build123d exactly.

`Assembly.locate()` still receives these objects; build123d reads only `.wrapped`, which both types expose as a `TopLoc_Location`. Verified at runtime.

Stacked on #429.
