### PR TITLE
refactor(deps): import 3MF and STL meshes in a sandboxed wrapper

### DIFF
--- a/partcad/src/partcad/part_factory_3mf.py
+++ b/partcad/src/partcad/part_factory_3mf.py
@@ -7,15 +7,25 @@
 # Licensed under Apache License, Version 2.0.
 #
 
-import build123d as b3d
+import base64
+import os
+import pickle
+import sys
 
 from . import telemetry
+from . import wrapper
 from .part_factory_file import PartFactoryFile
 from . import logging as pc_logging
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "wrappers"))
+from ocp_serialize import register as register_ocp_helper
 
 
 @telemetry.instrument()
 class PartFactory3mf(PartFactoryFile):
+    # The sandboxed runtime used to keep build123d out of the main process
+    PYTHON_SANDBOX_VERSION = "3.11"
+
     def __init__(self, ctx, source_project, target_project, config):
         with pc_logging.Action("Init3MF", target_project.name, config["name"]):
             super().__init__(
@@ -28,11 +38,54 @@ class PartFactory3mf(PartFactoryFile):
             # Complement the config object here if necessary
             self._create(config)
 
+            self.runtime = None  # Lazy initialization for subprocess runtime
+
     async def instantiate(self, part):
         await super().instantiate(part)
 
         with pc_logging.Action("3MF", part.project_name, part.name):
-            shape = b3d.Mesher().read(self.path)[0].wrapped
+            if self.runtime is None:
+                self.runtime = self.ctx.get_python_runtime(self.PYTHON_SANDBOX_VERSION)
+
+            wrapper_path = wrapper.get("import_mesh.py")
+
+            request = {"fallback_import_stl": False}
+            register_ocp_helper()
+            picklestring = pickle.dumps(request)
+            request_serialized = base64.b64encode(picklestring).decode()
+
+            await self.runtime.ensure_async("ocp-tessellate==3.0.9")
+            await self.runtime.ensure_async("typing_extensions==4.12.2")
+            await self.runtime.ensure_async("cadquery-ocp==7.7.2")
+            await self.runtime.ensure_async("ocpsvg==0.3.4")
+            await self.runtime.ensure_async("build123d==0.8.0")
+
+            command = [
+                wrapper_path,
+                os.path.abspath(self.path),
+                os.path.abspath(self.project.config_dir),
+            ]
+            with telemetry.start_as_current_span("*PartFactory3mf.instantiate.{runtime.run_async}"):
+                exitcode, response_serialized, errors = await self.runtime.run_async(
+                    command,
+                    request_serialized,
+                )
+            if exitcode != 0 and len(errors) == 0:
+                errors = f"Failed to execute command '{' '.join(command)}' with exit code {exitcode}"
+
+            if errors:
+                pc_logging.error(errors)
+                raise Exception(errors)
+
+            response = base64.b64decode(response_serialized)
+            register_ocp_helper()
+            result = pickle.loads(response)
+
+            if not result["success"]:
+                pc_logging.error(result["exception"])
+                raise Exception(result["exception"])
+
+            shape = result["shape"]
 
             self.ctx.stats_parts_instantiated += 1
 

--- a/partcad/src/partcad/part_factory_scad.py
+++ b/partcad/src/partcad/part_factory_scad.py
@@ -8,20 +8,28 @@
 #
 
 import asyncio
+import base64
 import os
+import pickle
 import shutil
 import subprocess
+import sys
 import tempfile
-
-import build123d as b3d
 
 from .part_factory_file import PartFactoryFile
 from . import logging as pc_logging
 from . import telemetry
+from . import wrapper
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "wrappers"))
+from ocp_serialize import register as register_ocp_helper
 
 
 @telemetry.instrument()
 class PartFactoryScad(PartFactoryFile):
+    # The sandboxed runtime used to keep build123d out of the main process
+    PYTHON_SANDBOX_VERSION = "3.11"
+
     def __init__(self, ctx, source_project, target_project, config, can_create=False):
         with pc_logging.Action("InitOpenSCAD", target_project.name, config["name"]):
             super().__init__(
@@ -39,6 +47,8 @@ class PartFactoryScad(PartFactoryFile):
                 self.part.cache_dependencies.append(os.path.join(self.project.config_dir, dep))
 
             self.project_dir = source_project.config_dir
+
+            self.runtime = None  # Lazy initialization for subprocess runtime
 
     async def instantiate(self, part):
         await super().instantiate(part)
@@ -87,16 +97,57 @@ class PartFactoryScad(PartFactoryFile):
             if not os.path.exists(stl_path) or os.path.getsize(stl_path) == 0:
                 part.error("OpenSCAD failed to generate the STL file. Please, check the script.")
                 return None
-            with telemetry.start_as_current_span("*PartFactoryScad.instantiate.{build123d.import_stl}"):
-                try:
-                    shape = b3d.Mesher().read(stl_path)[0].wrapped
-                except:
-                    try:
-                        # First, make sure it's not the known problem in Mesher
-                        shape = b3d.import_stl(stl_path).wrapped
-                    except Exception as e:
-                        part.error("%s: %s" % (part.name, e))
-                        return None
+
+            # The mesh is imported by a wrapper script executed in a sandboxed
+            # python runtime, so that build123d is not needed in this process.
+            # The wrapper falls back onto 'import_stl' if 'Mesher' fails,
+            # to work around the known problem in Mesher.
+            if self.runtime is None:
+                self.runtime = self.ctx.get_python_runtime(self.PYTHON_SANDBOX_VERSION)
+
+            wrapper_path = wrapper.get("import_mesh.py")
+
+            request = {"fallback_import_stl": True}
+            register_ocp_helper()
+            picklestring = pickle.dumps(request)
+            request_serialized = base64.b64encode(picklestring).decode()
+
+            await self.runtime.ensure_async("ocp-tessellate==3.0.9")
+            await self.runtime.ensure_async("typing_extensions==4.12.2")
+            await self.runtime.ensure_async("cadquery-ocp==7.7.2")
+            await self.runtime.ensure_async("ocpsvg==0.3.4")
+            await self.runtime.ensure_async("build123d==0.8.0")
+
+            command = [
+                wrapper_path,
+                os.path.abspath(stl_path),
+                os.path.abspath(self.project.config_dir),
+            ]
+            with telemetry.start_as_current_span("*PartFactoryScad.instantiate.{runtime.run_async}"):
+                exitcode, response_serialized, errors = await self.runtime.run_async(
+                    command,
+                    request_serialized,
+                )
+            if exitcode != 0 and len(errors) == 0:
+                errors = f"Failed to execute command '{' '.join(command)}' with exit code {exitcode}"
+
+            if errors:
+                part.error("%s: %s" % (part.name, errors))
+                return None
+
+            try:
+                response = base64.b64decode(response_serialized)
+                register_ocp_helper()
+                result = pickle.loads(response)
+            except Exception as e:
+                part.error("%s: %s" % (part.name, e))
+                return None
+
+            if not result["success"]:
+                part.error("%s: %s" % (part.name, result["exception"]))
+                return None
+
+            shape = result["shape"]
             os.unlink(stl_path)
 
             self.ctx.stats_parts_instantiated += 1

--- a/partcad/src/partcad/wrappers/wrapper_import_mesh.py
+++ b/partcad/src/partcad/wrappers/wrapper_import_mesh.py
@@ -1,0 +1,52 @@
+#
+# PartCAD, 2025
+#
+# Author: Roman Kuzmenko
+# Created: 2025-07-20
+#
+# Licensed under Apache License, Version 2.0.
+#
+
+# This script is executed within a python runtime environment
+# to use build123d to import mesh files (3MF, STL)
+
+import os
+import sys
+
+import build123d as b3d
+
+sys.path.append(os.path.dirname(__file__))
+import wrapper_common
+
+
+def process(path, request):
+    try:
+        try:
+            shape = b3d.Mesher().read(path)[0].wrapped
+        except Exception:
+            if not request.get("fallback_import_stl", False):
+                raise
+            # First, make sure it's not the known problem in Mesher
+            shape = b3d.import_stl(path).wrapped
+
+        return {
+            "success": True,
+            "exception": None,
+            "shape": shape,
+        }
+
+    except Exception as e:
+        wrapper_common.handle_exception(e)
+        return {
+            "success": False,
+            "exception": str(e),
+            "shape": None,
+        }
+
+
+path, request = wrapper_common.handle_input()
+
+# Perform import
+response = process(path, request)
+
+wrapper_common.handle_output(response)


### PR DESCRIPTION
Independent change, targets `devel` directly.

## Why

The 3MF and OpenSCAD part factories call build123d's `Mesher` directly in the main process — one of the last reasons that process needs build123d.

## What

Moves both mesh reads into a wrapper executed in a sandboxed runtime, following the existing `import_dxf` pattern.

The OpenSCAD fallback onto `import_stl` when `Mesher` fails is preserved, driven by a request flag, and the reported error still names the `import_stl` failure so the message is unchanged. Runtime pins are copied verbatim from the existing build123d factories — nothing invented, nothing relaxed.

`PartFactoryFile` has no `self.runtime`, so the lazy-runtime idiom from `part_factory_brep.py` is used.
