### PR TITLE
fix(test): update the assembly _SlowChild double to the convert() API

### DIFF
--- a/partcad/tests/unit/test_assembly.py
+++ b/partcad/tests/unit/test_assembly.py
@@ -80,7 +80,7 @@ class _SlowChild:
         self.name = name
         self.delay = delay
 
-    async def get_build123d(self, ctx):
+    async def convert(self, part_type, ctx=None):
         await asyncio.sleep(self.delay)
         return b3d.Solid.make_box(1.0, 1.0, 1.0)
 


### PR DESCRIPTION
## Why

`devel` is currently red on `test_assembly_child_order_is_declaration_order`:

```
AttributeError: '_SlowChild' object has no attribute 'convert'
partcad/src/partcad/assembly.py:73: AttributeError
```

This is a **merge-order incompatibility between two already-merged PRs**, not a regression in any one change:

- **#435** (make assemblies reproducible) added the test, whose `_SlowChild` stand-in implements `get_build123d(ctx)`.
- **#439** (add `Shape.convert()`) changed `Assembly._get_shape_real()` to call `child.item.convert("build123d", ctx)` and deprecated `get_build123d`.

Each passed CI against a `devel` that did not yet contain the other. Merged together, the test double no longer matches the API the assembly uses.

Reproduced on a clean `devel` checkout: `1 failed`.

## What

Give `_SlowChild` a `convert(part_type, ctx=None)` method matching what `Assembly` now calls. Test-only, one line.

After: `test_assembly.py` → `6 passed`.

## Impact

Every currently open PR inherits this failure through the merge-with-`devel` that PR CI runs, so this is the thing turning their Pytest jobs red across all platforms. Merging this unblocks them.
