### PR TITLE
feat(packaging): ship standalone PyInstaller bundles alongside the wheels

### DIFF
--- a/.github/workflows/build-standalone.yml
+++ b/.github/workflows/build-standalone.yml
@@ -1,0 +1,147 @@
+# Standalone (PyInstaller) bundles: the alternative to the Python wheels
+name: Standalone # Keep the action badge icon short
+
+on:
+  workflow_dispatch:
+  # Called by "deploy.yml", which uploads the bundles to the GitHub release.
+  workflow_call:
+  merge_group:
+  # Freezing pulls ~500MB of OpenCASCADE per runner, so this does not run on
+  # every change: only on the ones that can change what is frozen. The two
+  # lists are duplicated because GitHub Actions does not support YAML anchors.
+  # "main" is absent on purpose: a push there runs "deploy.yml", which calls
+  # this workflow itself. Listing it here would build everything twice.
+  push:
+    branches: ["devel"]
+    paths:
+      - "dev-tools/pyinstaller/**"
+      - "install.sh"
+      - ".github/workflows/build-standalone.yml"
+      - "partcad/src/**"
+      - "partcad-cli/src/**"
+      - "partcad/requirements*.txt"
+      - "partcad-cli/requirements*.txt"
+  pull_request:
+    branches: ["main", "devel"]
+    paths:
+      - "dev-tools/pyinstaller/**"
+      - "install.sh"
+      - ".github/workflows/build-standalone.yml"
+      - "partcad/src/**"
+      - "partcad-cli/src/**"
+      - "partcad/requirements*.txt"
+      - "partcad-cli/requirements*.txt"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
+
+jobs:
+  build:
+    name: "Build (${{ matrix.platform }})"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: linux-x86_64
+          # macos-latest is arm64. There is no macos x86_64 bundle: it would
+          # need macos-13, and no macos-13 job has ever started on the current
+          # runner plan (see the note in test.yml).
+          - os: macos-latest
+            platform: macos-arm64
+          - os: windows-latest
+            platform: windows-x86_64
+          # No linux arm64 bundle: cadquery-ocp 7.7.2 publishes no aarch64
+          # Linux wheel, so there is nothing to freeze there.
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          # The bundle embeds this interpreter, so this is the Python version
+          # every user of the standalone tools ends up running. It matches the
+          # version the wheels are published from in "deploy.yml".
+          python-version: "3.11"
+
+      - name: Install system prerequisites
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install --yes libcairo2-dev
+
+      - name: Build the standalone bundle
+        shell: bash
+        run: dev-tools/pyinstaller/build.sh
+
+      - name: Upload the bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: partcad-standalone-${{ matrix.platform }}
+          path: |
+            dist/standalone/*.tar.gz
+            dist/standalone/*.zip
+            dist/standalone/*.sha256
+          if-no-files-found: error
+          retention-days: 14
+
+  install:
+    name: "Install (${{ matrix.platform }})"
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: linux-x86_64
+          - os: macos-latest
+            platform: macos-arm64
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Download the bundle
+        uses: actions/download-artifact@v8
+        with:
+          name: partcad-standalone-${{ matrix.platform }}
+          path: archives
+
+      # This exercises the script users pipe into `sh`, against the archive
+      # this run produced, on a machine where PartCAD was never installed.
+      - name: Install with install.sh
+        shell: bash
+        run: |
+          version=$(sed -n 's/^__version__: str = "\(.*\)"$/\1/p' partcad/src/partcad/__init__.py)
+          sh install.sh \
+            --version "${version}" \
+            --base-url "file://${PWD}/archives" \
+            --install-dir "${HOME}/partcad-standalone" \
+            --bin-dir "${HOME}/partcad-bin"
+
+      - name: Run the installed commands
+        shell: bash
+        run: |
+          export PATH="${HOME}/partcad-bin:${PATH}"
+          # From a directory that is not the checkout, so nothing can resolve
+          # against the sources by accident.
+          cd "${HOME}"
+          pc version
+          partcad --help
+          pc init
+          pc list
+
+      - name: Uninstall with install.sh
+        shell: bash
+        run: |
+          sh install.sh --uninstall \
+            --install-dir "${HOME}/partcad-standalone" \
+            --bin-dir "${HOME}/partcad-bin"
+          test ! -e "${HOME}/partcad-bin/pc"
+          test ! -d "${HOME}/partcad-standalone"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,12 @@ permissions:
   contents: write
 
 jobs:
+  # The standalone bundles: the same tools packaged with their own Python
+  # interpreter, for users who have none. They are attached to the same GitHub
+  # release as the wheels, which is where "install.sh" downloads them from.
+  build-standalone:
+    uses: ./.github/workflows/build-standalone.yml
+
   # Keep the "build" job identical to "python-build.yml".
   # TODO(clairbee): include "python-build.yml" instead
   build:
@@ -79,6 +85,9 @@ jobs:
     name: Publish to PyPI
     needs:
       - build
+      # Deliberately blocking: a release that carries the wheels but not the
+      # bundles is a release "install.sh" cannot install.
+      - build-standalone
     runs-on: ubuntu-24.04
     environment:
       name: pypi
@@ -101,6 +110,34 @@ jobs:
           name: python-package-distributions-cli
           path: dist
 
+      # Kept out of "dist", which is uploaded to PyPI as a whole.
+      - name: Download standalone bundles
+        uses: actions/download-artifact@v8
+        with:
+          pattern: partcad-standalone-*
+          merge-multiple: true
+          path: standalone
+
+      # "install.sh" derives an asset name from `uname` and fails for the user
+      # if that asset is not on the release. Downloading artifacts does not fail
+      # when none match, so check here, before the release exists, rather than
+      # discovering a platform is missing after it is published.
+      - name: Check the standalone bundles are complete
+        run: |
+          missing=0
+          # The platforms built by "build-standalone.yml".
+          for platform in linux-x86_64 macos-arm64 windows-x86_64; do
+            archive=$(find standalone -type f -name "partcad-*-${platform}.*" ! -name "*.sha256")
+            checksum=$(find standalone -type f -name "partcad-*-${platform}.*.sha256")
+            if [ -z "${archive}" ] || [ -z "${checksum}" ]; then
+              echo "::error::no standalone bundle for ${platform}"
+              missing=1
+            else
+              echo "${archive} $(stat -c%s "${archive}") bytes"
+            fi
+          done
+          exit "${missing}"
+
       - name: Determine the release tag
         if: github.ref == 'refs/heads/main'
         run: |
@@ -115,6 +152,7 @@ jobs:
         run: |
           gh release create '${{ env.MERGED_TAG }}' --repo '${{ github.repository }}' --notes "";
           gh release upload '${{ env.MERGED_TAG }}' dist/** --repo '${{ github.repository }}'
+          gh release upload '${{ env.MERGED_TAG }}' standalone/** --repo '${{ github.repository }}'
 
       - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,12 @@ __pycache__
 *.prof
 *.pyc
 **/.DS_Store
+/build
+/dist
 /partcad-cli/build
 /partcad-cli/dist
+# Copied in from the repository root by the wheel and standalone builds
+/partcad-cli/LICENSE.txt
 /partcad/build
 /partcad/dist
 allure-report/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,13 @@ poetry run behave                                                               
 
 Lint/format (Python): `black`, `flake8`, `isort` — configured in `pyproject.toml`.
 
+### Packaging
+
+Two artifacts ship from this repo: the Python wheels (`partcad`, `partcad-cli` on PyPI) and the standalone
+PyInstaller bundles for users who have no Python. Adding a runtime dependency, an optional extra, or a file
+that is read at runtime can be invisible to the frozen bundle and break it while the wheels stay fine — see
+`dev-tools/pyinstaller/README.md` before doing any of those.
+
 ### Committing
 
 This repo uses `pre-commit` (config at `dev-tools/pre-commit-config.yaml`) to run formatting/lint checks,

--- a/README.md
+++ b/README.md
@@ -210,6 +210,19 @@ pip install -U partcad-cli
 - On **macOS**, make sure XCode and command lines tools are installed. Also, use `mamba` should you experience
   difficulties on macOS with the ARM architecture.
 
+### Command-Line Interface without Python
+
+If Python is not installed, or you would rather not maintain a Python environment for PartCAD, install the
+standalone build instead. It is the same `pc` and `partcad` commands, packaged with their own interpreter:
+
+```shell
+curl -fsSL https://raw.githubusercontent.com/partcad/partcad/main/install.sh | sh
+```
+
+It installs into `~/.local/share/partcad` and links the commands into `~/.local/bin`, without `sudo`. See
+[Installation](https://partcad.readthedocs.io/en/latest/installation.html) for the options, for Windows, and for
+uninstalling.
+
 ### PartCAD development
 
 Refer to the [Quick Start] guide for step-by-step instructions on setting up your development environment, adding

--- a/dev-tools/pyinstaller/README.md
+++ b/dev-tools/pyinstaller/README.md
@@ -1,0 +1,80 @@
+# Standalone PartCAD bundles
+
+The Python wheels on PyPI assume the user has Python, knows which Python, and is willing to keep an environment
+alive for it. This directory builds the alternative: a self-contained bundle, produced by
+[PyInstaller](https://pyinstaller.org/), that carries its own interpreter and every dependency. Users install it
+with [`install.sh`](../../install.sh) and never see Python.
+
+| | wheels | standalone bundle |
+| --- | --- | --- |
+| Install | `pip install -U partcad-cli` | `curl -fsSL .../install.sh \| sh` |
+| Needs Python | yes, 3.10-3.12 | no |
+| Size | ~15MB plus whatever pip resolves | ~800MB unpacked, ~230MB compressed |
+| Optional extras (`ai`, `lint`) | installed on demand | always included |
+| Importable as a library | yes | no, it is only the CLI |
+
+## Files
+
+- `partcad.spec` - the PyInstaller spec. It is the interesting file: it lists what PyInstaller cannot find on
+  its own, and says why for each entry.
+- `entrypoint.py` - what the frozen executables run, in place of the console scripts a wheel would generate.
+- `build.sh` - prepares the environment, freezes, smoke tests, and packs the archive.
+
+## Building
+
+From the repository root, inside the [dev container](../../docs/source/contributing.rst):
+
+```bash
+dev-tools/pyinstaller/build.sh
+```
+
+That installs the build dependencies into the active environment (including PartCAD itself, from this
+checkout), so use a throwaway virtualenv rather than the project one:
+
+```bash
+python -m venv /tmp/pyi-venv
+PYTHON=/tmp/pyi-venv/bin/python dev-tools/pyinstaller/build.sh
+```
+
+Pass `--no-install` to skip the dependency step when the environment is already prepared, and `--no-archive` to
+stop after the bundle and skip packing it.
+
+The results land in `dist/standalone/`: the `partcad/` bundle, an archive named
+`partcad-<version>-<os>-<arch>.tar.gz` (`.zip` on Windows), and its `.sha256`. The archive name is a contract
+with `install.sh`, which derives the same name from `uname`.
+
+The bundle embeds the interpreter it was built with, so `PYTHON` decides the Python version users end up
+running. CI builds with 3.11, and 3.11 or 3.12 is required: PartCAD itself still supports 3.10, but
+`ocp_vscode` (what `pc inspect` hands shapes to) does not import there, and a dependency that cannot be
+imported cannot be frozen. `build.sh` checks that before it builds and says which import failed.
+
+## What the frozen bundle changes, and what it does not
+
+Freezing replaces the *installation*, not the architecture. PartCAD still runs CAD scripts (CadQuery,
+build123d, OpenSCAD) in a separate Python interpreter that it provisions itself with conda, and still clones
+package repositories with `git`. Both remain external prerequisites of the standalone bundle, exactly as they
+are for the wheels. `pc healthcheck` reports what is missing.
+
+That sandbox is also why `partcad/wrappers/*.py` are bundled as *data* rather than frozen as modules: they are
+handed to that other interpreter as a file path.
+
+## Adding a dependency
+
+A frozen bundle only contains what PyInstaller could prove is reachable. Anything imported by name at runtime
+is invisible to it and has to be named in `partcad.spec`. When adding to PartCAD:
+
+- an import written normally - nothing to do;
+- an `importlib.import_module(...)` call, an optional extra, or a plugin discovered by entry point - add it to
+  `partcad.spec` and say why;
+- a non-Python file read at runtime - add it to `datas` in `partcad.spec`, and remember `__file__` inside a
+  bundle points into the unpacked bundle directory, not into a `site-packages`;
+- a new CLI subcommand - nothing to do, `command_modules()` in the spec enumerates the `commands` tree.
+
+A missing entry does not fail the build. It fails at runtime, on the one code path that needed it, for users
+only. The `Standalone` workflow (`.github/workflows/build-standalone.yml`) builds every platform and then
+installs and runs the result, which is what catches this; run it with `workflow_dispatch` when in doubt.
+
+## Releasing
+
+`deploy.yml` calls the `Standalone` workflow on a push to `main` and uploads the archives to the same GitHub
+release as the wheels. `install.sh` downloads from there by default.

--- a/dev-tools/pyinstaller/build.sh
+++ b/dev-tools/pyinstaller/build.sh
@@ -26,6 +26,15 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+# On Windows this script runs in Git Bash, but the Python, pip and PyInstaller
+# it drives are native Windows programs: they read a Git Bash path like
+# "/d/a/partcad" as the nonexistent "\d\a\partcad". `cygpath -m` converts it to
+# the mixed form, "D:/a/partcad", which the native tools and Git Bash both
+# understand -- unlike `cygpath -w`, whose backslashes would need re-quoting
+# every time the path is interpolated below.
+if command -v cygpath >/dev/null 2>&1; then
+  REPO_ROOT="$(cygpath -m "${REPO_ROOT}")"
+fi
 SPEC_DIR="${REPO_ROOT}/dev-tools/pyinstaller"
 OUTPUT_DIR="${REPO_ROOT}/dist/standalone"
 PYTHON="${PYTHON:-python3}"
@@ -73,8 +82,11 @@ esac
 PLATFORM="${OS_NAME}-${ARCH_NAME}"
 if [ "${OS_NAME}" = "windows" ]; then
   ARCHIVE_EXT="zip"
+  # PyInstaller names the executables `pc.exe` and `partcad.exe` there.
+  EXE_SUFFIX=".exe"
 else
   ARCHIVE_EXT="tar.gz"
+  EXE_SUFFIX=""
 fi
 
 VERSION="$("${PYTHON}" -c "
@@ -161,8 +173,8 @@ echo "==> Smoke testing the bundle"
 # depends on the source tree still works when started next to it.
 SMOKE_DIR="$(mktemp -d)"
 trap 'rm -rf "${SMOKE_DIR}"' EXIT
-(cd "${SMOKE_DIR}" && "${BUNDLE_DIR}/pc" version)
-(cd "${SMOKE_DIR}" && "${BUNDLE_DIR}/partcad" --help >/dev/null)
+(cd "${SMOKE_DIR}" && "${BUNDLE_DIR}/pc${EXE_SUFFIX}" version)
+(cd "${SMOKE_DIR}" && "${BUNDLE_DIR}/partcad${EXE_SUFFIX}" --help >/dev/null)
 
 if [ "${CREATE_ARCHIVE}" = "0" ]; then
   echo "==> Bundle: ${BUNDLE_DIR}"

--- a/dev-tools/pyinstaller/build.sh
+++ b/dev-tools/pyinstaller/build.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+# Builds the standalone PartCAD command line tools with PyInstaller and packs
+# them into the archive that `install.sh` downloads.
+#
+# Usage (from the repository root):
+#
+#   dev-tools/pyinstaller/build.sh              # install dependencies, then build
+#   dev-tools/pyinstaller/build.sh --no-install # build only, dependencies are in place
+#   dev-tools/pyinstaller/build.sh --no-archive # leave the bundle unpacked, skip the archive
+#
+# The environment variable PYTHON selects the interpreter to freeze (default
+# `python3`); the bundle embeds that exact interpreter, so it decides the
+# Python version users end up running.
+#
+# Output (relative to the repository root):
+#
+#   dist/standalone/partcad/                      the bundle
+#   dist/standalone/partcad-<version>-<platform>.<ext>       the archive
+#   dist/standalone/partcad-<version>-<platform>.<ext>.sha256
+
+set -euo pipefail
+
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+SPEC_DIR="${REPO_ROOT}/dev-tools/pyinstaller"
+OUTPUT_DIR="${REPO_ROOT}/dist/standalone"
+PYTHON="${PYTHON:-python3}"
+
+INSTALL_DEPENDENCIES=1
+CREATE_ARCHIVE=1
+for arg in "$@"; do
+  case "${arg}" in
+  --no-install) INSTALL_DEPENDENCIES=0 ;;
+  --no-archive) CREATE_ARCHIVE=0 ;;
+  -h | --help)
+    sed -n '7,25p' "${BASH_SOURCE[0]}"
+    exit 0
+    ;;
+  *)
+    echo "error: unknown option '${arg}'" >&2
+    exit 2
+    ;;
+  esac
+done
+
+################################################  PLATFORM  ##################################################
+
+# The archive name has to say what the bundle runs on, and has to agree with
+# the names `install.sh` derives from `uname`. Keep the two in sync.
+case "$(uname -s)" in
+Linux*) OS_NAME="linux" ;;
+Darwin*) OS_NAME="macos" ;;
+MINGW* | MSYS* | CYGWIN*) OS_NAME="windows" ;;
+*)
+  echo "error: unsupported operating system '$(uname -s)'" >&2
+  exit 1
+  ;;
+esac
+
+case "$(uname -m)" in
+x86_64 | amd64 | AMD64) ARCH_NAME="x86_64" ;;
+arm64 | aarch64) ARCH_NAME="arm64" ;;
+*)
+  echo "error: unsupported architecture '$(uname -m)'" >&2
+  exit 1
+  ;;
+esac
+
+PLATFORM="${OS_NAME}-${ARCH_NAME}"
+if [ "${OS_NAME}" = "windows" ]; then
+  ARCHIVE_EXT="zip"
+else
+  ARCHIVE_EXT="tar.gz"
+fi
+
+VERSION="$("${PYTHON}" -c "
+import re, pathlib
+source = pathlib.Path('${REPO_ROOT}/partcad/src/partcad/__init__.py').read_text()
+print(re.search(r'__version__: str = \"([^\"]+)\"', source).group(1))
+")"
+
+echo "==> Building PartCAD ${VERSION} for ${PLATFORM} with $("${PYTHON}" --version)"
+
+##############################################  DEPENDENCIES  ################################################
+
+if [ "${INSTALL_DEPENDENCIES}" = "1" ]; then
+  echo "==> Installing build dependencies"
+  "${PYTHON}" -m pip install --upgrade pip wheel setuptools
+  "${PYTHON}" -m pip install "pyinstaller>=6.11"
+
+  # `partcad-cli` declares its license by a path inside its own directory, but
+  # the file itself only exists in the repository root. The wheel build in
+  # "deploy.yml" copies it the same way.
+  cp "${REPO_ROOT}/LICENSE.txt" "${REPO_ROOT}/partcad-cli/"
+
+  echo "==> Installing PartCAD from this checkout"
+  # A frozen bundle cannot be extended with pip afterwards, so the optional
+  # extras that the wheels leave to the user are all built in.
+  "${PYTHON}" -m pip install "${REPO_ROOT}/partcad[ai,lint]"
+  # This satisfies the `partcad==<version>` pin of `partcad-cli` with the local
+  # build rather than with the release on PyPI.
+  "${PYTHON}" -m pip install "${REPO_ROOT}/partcad-cli"
+fi
+
+##############################################  PRE-FLIGHT  ##################################################
+
+# PartCAD imports these by name at runtime, so PyInstaller only finds them by
+# importing them here, at build time. When that import fails, the collection is
+# skipped with a warning buried in the build log and the bundle is built
+# anyway: complete to look at, broken on the one code path that needed the
+# package, for users only. Fail here instead, where it is still visible.
+echo "==> Checking the dependencies that are imported by name"
+"${PYTHON}" - <<'PREFLIGHT'
+import importlib
+import sys
+
+REQUIRED = {
+    "OCP": "the geometry kernel",
+    "build123d": "the geometry kernel",
+    "ocp_vscode": "`pc inspect` (needs Python 3.11 or newer)",
+    "openai": "the OpenAI provider",
+    "ollama": "the Ollama provider",
+    "google.generativeai": "the Google Gemini provider",
+    "ruff.__main__": "`pc lint` of Python files",
+}
+
+broken = []
+for name, used_by in REQUIRED.items():
+    try:
+        importlib.import_module(name)
+    except Exception as e:
+        broken.append(f"  {name}: {used_by}\n    {type(e).__name__}: {e}")
+
+if broken:
+    print("error: these cannot be imported in this build environment, so they")
+    print("       cannot be frozen into the bundle either:")
+    print()
+    print("\n".join(broken))
+    sys.exit(1)
+PREFLIGHT
+
+################################################  FREEZE  ####################################################
+
+echo "==> Freezing"
+rm -rf "${OUTPUT_DIR}/partcad"
+"${PYTHON}" -m PyInstaller \
+  --clean \
+  --noconfirm \
+  --distpath "${OUTPUT_DIR}" \
+  --workpath "${REPO_ROOT}/build/pyinstaller" \
+  "${SPEC_DIR}/partcad.spec"
+
+BUNDLE_DIR="${OUTPUT_DIR}/partcad"
+
+echo "==> Smoke testing the bundle"
+# Run from a directory that is not the checkout: a bundle that accidentally
+# depends on the source tree still works when started next to it.
+SMOKE_DIR="$(mktemp -d)"
+trap 'rm -rf "${SMOKE_DIR}"' EXIT
+(cd "${SMOKE_DIR}" && "${BUNDLE_DIR}/pc" version)
+(cd "${SMOKE_DIR}" && "${BUNDLE_DIR}/partcad" --help >/dev/null)
+
+if [ "${CREATE_ARCHIVE}" = "0" ]; then
+  echo "==> Bundle: ${BUNDLE_DIR}"
+  exit 0
+fi
+
+################################################  PACKAGE  ###################################################
+
+ARCHIVE_NAME="partcad-${VERSION}-${PLATFORM}.${ARCHIVE_EXT}"
+ARCHIVE_PATH="${OUTPUT_DIR}/${ARCHIVE_NAME}"
+
+echo "==> Packing ${ARCHIVE_NAME}"
+rm -f "${ARCHIVE_PATH}" "${ARCHIVE_PATH}.sha256"
+if [ "${ARCHIVE_EXT}" = "zip" ]; then
+  (cd "${OUTPUT_DIR}" && "${PYTHON}" -m zipfile -c "${ARCHIVE_NAME}" partcad)
+else
+  # The archive unpacks to a single `partcad/` directory, which is what
+  # `install.sh` expects to move into place.
+  tar -czf "${ARCHIVE_PATH}" -C "${OUTPUT_DIR}" partcad
+fi
+
+# `install.sh` verifies this checksum before it unpacks anything.
+(
+  cd "${OUTPUT_DIR}"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "${ARCHIVE_NAME}" >"${ARCHIVE_NAME}.sha256"
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "${ARCHIVE_NAME}" >"${ARCHIVE_NAME}.sha256"
+  else
+    "${PYTHON}" -c "
+import hashlib, pathlib
+name = '${ARCHIVE_NAME}'
+digest = hashlib.sha256(pathlib.Path(name).read_bytes()).hexdigest()
+pathlib.Path(name + '.sha256').write_text(f'{digest}  {name}\n')
+"
+  fi
+)
+
+echo "==> Done"
+echo "    bundle:   ${BUNDLE_DIR}"
+echo "    archive:  ${ARCHIVE_PATH}"
+echo "    checksum: ${ARCHIVE_PATH}.sha256"

--- a/dev-tools/pyinstaller/build.sh
+++ b/dev-tools/pyinstaller/build.sh
@@ -99,10 +99,18 @@ echo "==> Building PartCAD ${VERSION} for ${PLATFORM} with $("${PYTHON}" --versi
 
 ##############################################  DEPENDENCIES  ################################################
 
+# setuptools 82 removed `pkg_resources` outright, and PyInstaller's
+# `pyi_rth_pkgres` runtime hook still expects it: the bundle then aborts at
+# start-up with "module 'pkg_resources' has no attribute 'NullProvider'".
+# Passed to every install below, because installing PartCAD is otherwise free to
+# pull the newest setuptools back in. Drop the bound once PyInstaller ships a
+# hook that copes.
+SETUPTOOLS_BOUND="setuptools<82"
+
 if [ "${INSTALL_DEPENDENCIES}" = "1" ]; then
   echo "==> Installing build dependencies"
-  "${PYTHON}" -m pip install --upgrade pip wheel setuptools
-  "${PYTHON}" -m pip install "pyinstaller>=6.11"
+  "${PYTHON}" -m pip install --upgrade pip wheel "${SETUPTOOLS_BOUND}"
+  "${PYTHON}" -m pip install "pyinstaller>=6.11" "${SETUPTOOLS_BOUND}"
 
   # `partcad-cli` declares its license by a path inside its own directory, but
   # the file itself only exists in the repository root. The wheel build in
@@ -112,10 +120,10 @@ if [ "${INSTALL_DEPENDENCIES}" = "1" ]; then
   echo "==> Installing PartCAD from this checkout"
   # A frozen bundle cannot be extended with pip afterwards, so the optional
   # extras that the wheels leave to the user are all built in.
-  "${PYTHON}" -m pip install "${REPO_ROOT}/partcad[ai,lint]"
+  "${PYTHON}" -m pip install "${REPO_ROOT}/partcad[ai,lint]" "${SETUPTOOLS_BOUND}"
   # This satisfies the `partcad==<version>` pin of `partcad-cli` with the local
   # build rather than with the release on PyPI.
-  "${PYTHON}" -m pip install "${REPO_ROOT}/partcad-cli"
+  "${PYTHON}" -m pip install "${REPO_ROOT}/partcad-cli" "${SETUPTOOLS_BOUND}"
 fi
 
 ##############################################  PRE-FLIGHT  ##################################################

--- a/dev-tools/pyinstaller/entrypoint.py
+++ b/dev-tools/pyinstaller/entrypoint.py
@@ -18,5 +18,17 @@ import sys
 
 from partcad_cli.click.command import main
 
+# The banner and the box drawing characters in the help output are not
+# encodable in the code page Windows hands a redirected stdout (cp1252), so
+# `pc --help > out.txt` there dies with a UnicodeEncodeError before printing
+# anything. A wheel inherits whatever encoding the user's Python was configured
+# with; the bundle owns its interpreter, so it can settle the question itself.
+# `errors="replace"` covers the streams that still cannot take UTF-8: garbled
+# output beats a traceback.
+for _stream in (sys.stdout, sys.stderr):
+    _reconfigure = getattr(_stream, "reconfigure", None)
+    if _reconfigure is not None:
+        _reconfigure(encoding="utf-8", errors="replace")
+
 if __name__ == "__main__":
     sys.exit(main())

--- a/dev-tools/pyinstaller/entrypoint.py
+++ b/dev-tools/pyinstaller/entrypoint.py
@@ -1,0 +1,22 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""Entry point of the frozen PartCAD command line tools.
+
+The wheels expose `pc` and `partcad` as console scripts generated from
+`[project.scripts]`. A frozen bundle has no console scripts, so this module
+takes their place: it is the script PyInstaller analyzes and runs.
+
+`click` derives the program name from `sys.argv[0]`, so the same frozen code
+prints itself as `pc` or as `partcad` depending on which of the two executables
+in the bundle was invoked.
+"""
+
+import sys
+
+from partcad_cli.click.command import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dev-tools/pyinstaller/partcad.spec
+++ b/dev-tools/pyinstaller/partcad.spec
@@ -1,0 +1,257 @@
+# -*- mode: python ; coding: utf-8 -*-
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""PyInstaller spec for the standalone PartCAD command line tools.
+
+Produces a one-directory bundle that carries its own Python interpreter, so
+``pc`` and ``partcad`` run on a machine where no Python is installed and no
+Python environment has to be managed. It is what ``install.sh`` downloads.
+
+One directory, not one file: the bundle is dominated by the ~500MB OCP
+extension module and its OpenCASCADE libraries, and a one-file build would
+unpack all of that into a temporary directory on every single invocation.
+
+The bundle replaces the *wheels*, not the sandbox. PartCAD still runs CAD
+scripts (CadQuery, build123d, OpenSCAD) in a separate Python interpreter it
+provisions itself through conda -- see ``partcad.runtime_python``. Freezing
+does not change that, which is why the wrapper scripts below are bundled as
+data files rather than as frozen modules: they are handed as a path to that
+other interpreter.
+
+Build it with ``dev-tools/pyinstaller/build.sh``, which prepares the
+environment this spec expects. To run PyInstaller directly, install ``partcad``
+and ``partcad-cli`` (with their ``ai`` and ``lint`` extras) plus ``pyinstaller``
+into the current environment first, then::
+
+    pyinstaller --clean --noconfirm dev-tools/pyinstaller/partcad.spec
+"""
+
+import os
+import sys
+from pathlib import Path
+
+from PyInstaller.utils.hooks import collect_all, collect_submodules, copy_metadata
+
+# `SPECPATH` is injected by PyInstaller and holds the directory of this file.
+SPEC_DIR = Path(SPECPATH).resolve()
+REPO_ROOT = SPEC_DIR.parents[1]
+PARTCAD_SRC = REPO_ROOT / "partcad" / "src"
+CLI_SRC = REPO_ROOT / "partcad-cli" / "src"
+
+IS_WINDOWS = sys.platform == "win32"
+
+datas = []
+binaries = []
+hiddenimports = []
+
+
+def add_package(name, include_metadata=False):
+    """Pull in everything a distribution needs, tolerating its absence.
+
+    Optional dependencies (the AI provider SDKs, the linter) are imported
+    lazily by PartCAD and are not installed in every environment PyInstaller
+    might be run from by hand. A bundle built without one of them stays usable,
+    it just reports the same "not installed" error the wheels report, so this
+    is a warning rather than a build failure. `build.sh`, which is how release
+    bundles are built, refuses to build an incomplete one.
+    """
+    try:
+        pkg_datas, pkg_binaries, pkg_hiddenimports = collect_all(name)
+    except Exception as e:  # pragma: no cover - build-time diagnostics
+        print(f"partcad.spec: skipping '{name}': {e}")
+        return
+    if not pkg_hiddenimports:
+        # `collect_all` imports the package to enumerate it and, when that
+        # import fails, returns its data files and no modules at all -- with a
+        # warning easily lost in the build log, and a bundle that only breaks
+        # once a user reaches that feature. `build.sh` checks these imports
+        # before the build for the same reason.
+        print(f"partcad.spec: WARNING: no modules collected for '{name}', it will be missing from the bundle")
+    datas.extend(pkg_datas)
+    binaries.extend(pkg_binaries)
+    hiddenimports.extend(pkg_hiddenimports)
+    if include_metadata:
+        add_metadata(name)
+
+
+def add_metadata(distribution):
+    """Ship a distribution's metadata, for code that reads its own version."""
+    try:
+        datas.extend(copy_metadata(distribution))
+    except Exception as e:  # pragma: no cover - build-time diagnostics
+        print(f"partcad.spec: no metadata for '{distribution}': {e}")
+
+
+def command_modules():
+    """Name every CLI subcommand module, for `partcad_cli.click.loader`.
+
+    The loader discovers subcommands by listing the ``commands`` directory and
+    imports the one that was asked for by name, so nothing references these
+    modules statically and PyInstaller cannot find them on its own.
+
+    They are enumerated from the source tree rather than with
+    ``collect_submodules`` because one of the packages is named ``import``,
+    which is a keyword: it is reachable through ``importlib.import_module``
+    (which is how the loader loads it) but not through an import statement.
+    """
+    root = CLI_SRC / "partcad_cli" / "click" / "commands"
+    modules = []
+    for path in sorted(root.rglob("*.py")):
+        parts = list(path.relative_to(CLI_SRC).with_suffix("").parts)
+        if parts[-1] == "__init__":
+            parts.pop()
+        modules.append(".".join(parts))
+    return modules
+
+
+#################################################  PARTCAD  ##################################################
+
+# The frozen modules come from the checkout (`pathex` below), so the data files
+# have to come from the checkout too, or the two could disagree.
+datas += [
+    # Executed by the sandbox interpreter, by path. They must exist as files.
+    (str(PARTCAD_SRC / "partcad" / "wrappers"), "partcad/wrappers"),
+    # Copied into new packages by `pc init`.
+    (str(PARTCAD_SRC / "partcad" / "template"), "partcad/template"),
+    # Read through `importlib.resources` by `pc lint`.
+    (str(PARTCAD_SRC / "partcad" / "schema"), "partcad/schema"),
+    # The loader lists this directory to enumerate the available subcommands.
+    (str(CLI_SRC / "partcad_cli" / "click" / "commands"), "partcad_cli/click/commands"),
+    # Redistributing a binary bundle means redistributing its dependencies.
+    (str(REPO_ROOT / "LICENSE.txt"), "."),
+]
+
+hiddenimports += collect_submodules("partcad")
+hiddenimports += command_modules()
+
+##############################################  DEPENDENCIES  ################################################
+
+# The geometry kernel. OCP is a single extension module that registers all of
+# its submodules (`OCP.TopoDS` and friends) at import time, so naming the top
+# level module is enough for the bundle -- but PyInstaller cannot see through
+# that, hence the explicit entry.
+hiddenimports += ["OCP"]
+add_package("build123d")
+add_package("ocpsvg")
+
+# Data-driven packages: they resolve resources or plugins at runtime, so their
+# non-Python files have to travel with them.
+add_package("jsonschema")
+add_package("jsonschema_specifications")
+add_package("referencing")
+add_package("vyper")
+
+# Telemetry. Sentry discovers its integrations by module name, and the
+# OpenTelemetry packages discover propagators and exporters through entry
+# points, which only exist if the metadata is bundled.
+hiddenimports += collect_submodules("sentry_sdk")
+for _dist in ("opentelemetry-api", "opentelemetry-sdk", "opentelemetry-semantic-conventions"):
+    add_metadata(_dist)
+hiddenimports += collect_submodules("opentelemetry")
+
+# Imported lazily, by name, so that a bundle stays useful without them.
+# `pc inspect` hands the shape to the OCP CAD Viewer.
+add_package("ocp_vscode")
+# AI providers. The wheels leave these to the `ai` extra, but a frozen bundle
+# cannot be extended with pip afterwards, so it carries all of them.
+add_package("openai", include_metadata=True)
+add_package("ollama", include_metadata=True)
+add_package("google.generativeai")
+add_metadata("google-generativeai")
+
+# `pc lint` runs the linter as a subprocess. `ruff.__main__.find_ruff_bin()`
+# looks in `sysconfig.get_path("scripts")` first, which inside a frozen bundle
+# resolves to `bin` (`Scripts` on Windows) next to the bundled interpreter, so
+# putting the executable there is enough for it to be found.
+add_package("ruff")
+_ruff_bin = Path(sys.prefix) / ("Scripts" if IS_WINDOWS else "bin") / ("ruff.exe" if IS_WINDOWS else "ruff")
+if _ruff_bin.is_file():
+    binaries += [(str(_ruff_bin), "Scripts" if IS_WINDOWS else "bin")]
+else:
+    print(f"partcad.spec: no ruff executable at '{_ruff_bin}', `pc lint` will not lint Python files")
+
+# The version PartCAD reports and sends with telemetry.
+add_metadata("partcad")
+add_metadata("partcad-cli")
+
+###############################################  ANALYSIS  ###################################################
+
+a = Analysis(
+    [str(SPEC_DIR / "entrypoint.py")],
+    # The checkout comes first so the bundle matches the working tree rather
+    # than whatever copy happens to be installed in the build environment.
+    pathex=[str(PARTCAD_SRC), str(CLI_SRC)],
+    binaries=binaries,
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[
+        # Test and development machinery that nothing in the CLI reaches.
+        "pytest",
+        "behave",
+        "nox",
+        "sphinx",
+        "tkinter",
+        # An IPython dependency, ~30MB of source code completion machinery that
+        # is reachable only from an interactive prompt PartCAD never opens.
+        "jedi",
+    ],
+    noarchive=False,
+    optimize=0,
+)
+
+##################################################  TRIM  ####################################################
+
+# `google-api-python-client` ships a cached copy of the REST discovery document
+# of every Google API, ~100MB of JSON, and PyInstaller has a hook that collects
+# all of them. They are only read by `googleapiclient.discovery.build()`, which
+# nothing here calls: the Gemini SDK talks to the generative language API over
+# gRPC. Dropping the documents keeps the package importable and takes an eighth
+# off the bundle. This runs after the analysis because that is where the hook
+# added them; filtering the `datas` above would not see them.
+_discovery_documents = os.path.join("googleapiclient", "discovery_cache", "documents")
+a.datas = [entry for entry in a.datas if _discovery_documents not in os.path.normpath(entry[0])]
+
+pyz = PYZ(a.pure)
+
+
+def executable(name):
+    """One console executable per name the CLI is invoked as."""
+    return EXE(
+        pyz,
+        a.scripts,
+        [],
+        exclude_binaries=True,
+        name=name,
+        debug=False,
+        bootloader_ignore_signals=False,
+        # Stripping is left off: the size it saves is noise next to OCP, and
+        # it has broken extension modules on macOS before.
+        strip=False,
+        # UPX is left off deliberately: it does not help a bundle this size and
+        # it makes every start-up slower.
+        upx=False,
+        console=True,
+        disable_windowed_traceback=False,
+        argv_emulation=False,
+        target_arch=None,
+        codesign_identity=None,
+        entitlements_file=None,
+    )
+
+
+coll = COLLECT(
+    executable("pc"),
+    executable("partcad"),
+    a.binaries,
+    a.datas,
+    strip=False,
+    upx=False,
+    upx_exclude=[],
+    name="partcad",
+)

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -16,6 +16,12 @@ getting tested on Linux, MacOS and Windows.
 
 .. note::
 
+  No Python on the machine, or no interest in maintaining a Python environment?
+  Install the :ref:`standalone command line tools <standalone-cli>` instead. They are
+  the same tools, shipped with their own interpreter.
+
+.. note::
+
   PartCAD works best when `conda <https://docs.conda.io/>`_ is installed.
   If that doesn't help (e.g. MacOS+arm64) then try ``mamba``.
   On Windows, PartCAD must be used inside a ``conda`` environment.
@@ -76,6 +82,165 @@ plain-text logs, and ``-p PATH`` to select the package (a ``partcad.yaml`` file 
 one). Run ``pc <command> --help`` to see the options for any command.
 
 For a full command reference, see :doc:`cli`.
+
+
+.. _standalone-cli:
+
+=========================================
+Standalone command line tools (no Python)
+=========================================
+
+The standalone build is the same ``pc`` and ``partcad`` commands, packaged with their own Python
+interpreter and every dependency they need. Nothing is installed into a Python environment, because
+no Python environment is involved: there is nothing to activate, nothing to keep on the right version,
+and nothing to break the next time some other tool upgrades Python.
+
+Use it if Python is not installed, if the Python that is installed belongs to the operating system and
+should be left alone, or if PartCAD is simply a tool to run rather than a library to program against.
+Use the wheels instead if you want to ``import partcad`` from your own scripts.
+
+Install
+=======
+
+On Linux and MacOS:
+
+.. code-block:: shell
+
+  $ curl -fsSL https://raw.githubusercontent.com/partcad/partcad/main/install.sh | sh
+
+That downloads the bundle for the current operating system and architecture from the latest
+`GitHub release <https://github.com/partcad/partcad/releases>`_, verifies its checksum, unpacks it into
+``~/.local/share/partcad/<version>``, and links ``pc`` and ``partcad`` into ``~/.local/bin``.
+Nothing else on the system is touched, and no ``sudo`` is asked for. If ``~/.local/bin`` is not on your
+``PATH``, the installer says so and prints the line to add.
+
+The bundle is around 800MB unpacked (a quarter of a gigabyte to download): most of it is the OpenCASCADE
+geometry kernel, which the wheels download too, just at ``pip install`` time.
+
+Supported platforms are Linux on x86_64, and MacOS on Apple silicon. Windows is covered by the
+``.zip`` archive under :ref:`manual installation <standalone-manual>`.
+
+Options
+=======
+
+Options go after ``sh -s --``:
+
+.. code-block:: shell
+
+  # A specific version rather than the latest release
+  $ curl -fsSL https://raw.githubusercontent.com/partcad/partcad/main/install.sh | sh -s -- --version 0.7.146
+
+  # Somewhere else entirely
+  $ curl -fsSL https://raw.githubusercontent.com/partcad/partcad/main/install.sh | \
+      sh -s -- --install-dir /opt/partcad --bin-dir /usr/local/bin
+
+  # What else is there
+  $ curl -fsSL https://raw.githubusercontent.com/partcad/partcad/main/install.sh | sh -s -- --help
+
+============================== ================================ ==========================================
+Option                         Environment variable             Default
+============================== ================================ ==========================================
+``--version <version>``        ``PARTCAD_VERSION``              the latest release
+``--install-dir <dir>``        ``PARTCAD_INSTALL_DIR``          ``${XDG_DATA_HOME:-~/.local/share}/partcad``
+``--bin-dir <dir>``            ``PARTCAD_BIN_DIR``              ``~/.local/bin``
+``--base-url <url>``           ``PARTCAD_BASE_URL``             the GitHub release for the version
+``--repository <owner/name>``  ``PARTCAD_REPOSITORY``           ``partcad/partcad``
+============================== ================================ ==========================================
+
+Installing several versions side by side is fine: each one unpacks into its own directory, and the
+last install wins the ``pc`` and ``partcad`` links. Installing an already installed version replaces it.
+
+Upgrade and uninstall
+=====================
+
+Upgrading is installing again: re-run the same command.
+
+.. code-block:: shell
+
+  $ curl -fsSL https://raw.githubusercontent.com/partcad/partcad/main/install.sh | sh -s -- --uninstall
+
+Uninstalling removes the bundle and the two links, and only the links that point at the bundle, so a
+``pc`` installed from a wheel is left alone. The PartCAD cache and configuration in ``~/.partcad`` are kept;
+delete that directory as well to leave nothing behind.
+
+Installing a development build
+==============================
+
+The installer is a file in the repository, so any branch, tag, or pull request has its own copy of it, and
+the URL selects which one runs. To install using the script as it exists on the ``devel`` branch:
+
+.. code-block:: shell
+
+  $ curl -fsSL https://raw.githubusercontent.com/partcad/partcad/devel/install.sh | sh
+
+For a pull request, use the branch it comes from, or its head commit:
+
+.. code-block:: shell
+
+  $ curl -fsSL https://raw.githubusercontent.com/partcad/partcad/<branch-or-commit>/install.sh | sh
+
+.. note::
+
+  The URL only decides which *installer* runs. By default that installer still downloads the bundle of the
+  latest release, because bundles are published per release, not per commit. To install the bundle a branch
+  or pull request actually built, take it from the ``Standalone`` workflow run of that branch or pull
+  request: open the run on GitHub, download the ``partcad-standalone-<platform>`` artifact, unzip it, and
+  point the installer at the directory holding the archive.
+
+  .. code-block:: shell
+
+    $ unzip partcad-standalone-linux-x86_64.zip -d /tmp/partcad-build
+    $ curl -fsSL https://raw.githubusercontent.com/partcad/partcad/devel/install.sh | \
+        sh -s -- --version <version> --base-url "file:///tmp/partcad-build"
+
+  ``--base-url`` accepts any URL, so a bundle published anywhere else (an internal mirror, a file server)
+  installs the same way.
+
+.. _standalone-manual:
+
+Manual installation
+===================
+
+The archives are attached to every `GitHub release <https://github.com/partcad/partcad/releases>`_ next to
+the wheels, together with a ``.sha256`` file each:
+
+* ``partcad-<version>-linux-x86_64.tar.gz``
+* ``partcad-<version>-macos-arm64.tar.gz``
+* ``partcad-<version>-windows-x86_64.zip``
+
+Each one unpacks into a single ``partcad/`` directory holding ``pc``, ``partcad``, and everything they
+need. Put that directory anywhere and run the commands from it, or add it to ``PATH``. On Windows, unpack
+the ``.zip`` and add the resulting directory to ``PATH`` -- there is no shell script installer for Windows.
+
+.. code-block:: shell
+
+  $ tar -xzf partcad-<version>-linux-x86_64.tar.gz -C ~/.local/share
+  $ ~/.local/share/partcad/pc version
+
+.. note::
+
+  On MacOS, downloading the archive with a browser marks it as quarantined, and Gatekeeper then refuses to
+  run the unpacked commands. Installing with ``install.sh``, or downloading with ``curl``, avoids that.
+  To clear it after the fact: ``xattr -dr com.apple.quarantine <directory>``.
+
+What is included, and what is not
+=================================
+
+The bundle carries everything the wheels would install, including the optional extras that the wheels leave
+to the user: all the AI providers (``ai-google``, ``ai-openai``, ``ai-ollama``) and the Python linter
+(``lint``). A frozen bundle cannot be extended afterwards, so it ships complete.
+
+Two things are deliberately not in it, because PartCAD runs them as external programs rather than importing
+them, exactly as the wheels do:
+
+* **git**, used to fetch package repositories.
+* **conda** (or **mamba**), used to build the sandbox in which PartCAD runs CAD scripts.
+
+Both are only needed for the features that use them. Run ``pc healthcheck`` to see what is missing on the
+current machine.
+
+The bundle provides the command line tools only. The ``partcad`` Python module for CAD-as-code scripts is
+a wheel: ``python -m pip install -U partcad``.
 
 
 =====================================

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -59,6 +59,15 @@ Typical problems
 When running `pc ...` commands, getting: "pc is not a recognized command..."
 
 - Make sure that Conda environment is activated in the current terminal, for example by running `conda info`
+- With the :ref:`standalone build <standalone-cli>`, there is no environment to activate: the commands are
+  linked into ``~/.local/bin``, which has to be on ``PATH``. Run ``~/.local/bin/pc version`` to confirm the
+  installation itself is fine, then add the directory to ``PATH``.
+
+Which one is running, the standalone build or a wheel?
+
+- ``command -v pc`` says. A path under ``~/.local/share/partcad`` (or wherever ``--install-dir`` pointed) is
+  the standalone build; a path inside a Python environment is the wheel. Having both installed is supported,
+  but only the first on ``PATH`` runs.
 
 ========================
 PartCAD VSCode Extension

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,252 @@
+#!/bin/sh
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+# Installs the standalone PartCAD command line tools: a self-contained bundle
+# that carries its own Python interpreter, for machines that have no Python
+# installed and no interest in managing Python environments.
+#
+#   curl -fsSL https://raw.githubusercontent.com/partcad/partcad/main/install.sh | sh
+#
+# Run `... | sh -s -- --help` for the options.
+#
+# This script is written for POSIX `sh` on purpose: it has to run on whatever
+# shell a bare machine happens to have.
+
+set -eu
+
+REPOSITORY="${PARTCAD_REPOSITORY:-partcad/partcad}"
+VERSION="${PARTCAD_VERSION:-}"
+BASE_URL="${PARTCAD_BASE_URL:-}"
+INSTALL_DIR="${PARTCAD_INSTALL_DIR:-}"
+BIN_DIR="${PARTCAD_BIN_DIR:-}"
+UNINSTALL=0
+
+usage() {
+  cat <<'EOF'
+Install the standalone PartCAD command line tools.
+
+Usage:
+  curl -fsSL <this script> | sh
+  curl -fsSL <this script> | sh -s -- [options]
+
+Options:
+  --version <version>   Version to install (default: the latest release).
+  --install-dir <dir>   Where to unpack the bundle
+                        (default: ${XDG_DATA_HOME:-~/.local/share}/partcad).
+  --bin-dir <dir>       Where to link the `pc` and `partcad` commands
+                        (default: ~/.local/bin).
+  --base-url <url>      Directory holding the archives, instead of the GitHub
+                        release. Use it to install a build that is not
+                        released, such as one produced by a pull request.
+  --repository <owner/name>
+                        GitHub repository to install from
+                        (default: partcad/partcad).
+  --uninstall           Remove an installation made by this script.
+  --help                Show this message.
+
+Every option also has an environment variable: PARTCAD_VERSION,
+PARTCAD_INSTALL_DIR, PARTCAD_BIN_DIR, PARTCAD_BASE_URL, PARTCAD_REPOSITORY.
+EOF
+}
+
+log() { printf '%s\n' "$*"; }
+warn() { printf 'warning: %s\n' "$*" >&2; }
+fail() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+  --version)
+    VERSION="${2:-}"
+    shift 2
+    ;;
+  --install-dir)
+    INSTALL_DIR="${2:-}"
+    shift 2
+    ;;
+  --bin-dir)
+    BIN_DIR="${2:-}"
+    shift 2
+    ;;
+  --base-url)
+    BASE_URL="${2:-}"
+    shift 2
+    ;;
+  --repository)
+    REPOSITORY="${2:-}"
+    shift 2
+    ;;
+  --uninstall)
+    UNINSTALL=1
+    shift
+    ;;
+  --help | -h)
+    usage
+    exit 0
+    ;;
+  *) fail "unknown option '$1' (try --help)" ;;
+  esac
+done
+
+: "${INSTALL_DIR:=${XDG_DATA_HOME:-${HOME}/.local/share}/partcad}"
+: "${BIN_DIR:=${HOME}/.local/bin}"
+
+##############################################  UNINSTALL  ###################################################
+
+if [ "${UNINSTALL}" = "1" ]; then
+  for command_name in pc partcad; do
+    link="${BIN_DIR}/${command_name}"
+    # Only remove links this script owns. Anything else on PATH by that name,
+    # a wheel install of `pc` above all, is somebody else's.
+    if [ -L "${link}" ]; then
+      # Compared as written rather than resolved, so that a link left dangling
+      # by a half-removed installation is still recognized as ours.
+      case "$(readlink "${link}")" in
+      "${INSTALL_DIR}"/*)
+        rm -f "${link}"
+        log "Removed ${link}"
+        ;;
+      *) warn "left ${link} alone: it does not point into ${INSTALL_DIR}" ;;
+      esac
+    fi
+  done
+  if [ -d "${INSTALL_DIR}" ]; then
+    rm -rf "${INSTALL_DIR}"
+    log "Removed ${INSTALL_DIR}"
+  fi
+  log ""
+  log "PartCAD is uninstalled. Its cache and configuration in ~/.partcad were kept;"
+  log "remove that directory too if you want nothing left behind."
+  exit 0
+fi
+
+###############################################  PLATFORM  ###################################################
+
+case "$(uname -s)" in
+Linux) OS_NAME="linux" ;;
+Darwin) OS_NAME="macos" ;;
+MINGW* | MSYS* | CYGWIN*)
+  fail "this script does not support Windows. Download the .zip from
+       https://github.com/${REPOSITORY}/releases and unpack it, or install the
+       wheels with 'pip install -U partcad-cli'."
+  ;;
+*) fail "unsupported operating system '$(uname -s)'" ;;
+esac
+
+case "$(uname -m)" in
+x86_64 | amd64) ARCH_NAME="x86_64" ;;
+arm64 | aarch64) ARCH_NAME="arm64" ;;
+*) fail "unsupported architecture '$(uname -m)'" ;;
+esac
+
+PLATFORM="${OS_NAME}-${ARCH_NAME}"
+
+################################################  FETCH  #####################################################
+
+if command -v curl >/dev/null 2>&1; then
+  download() { curl -fsSL "$1" -o "$2"; }
+  read_url() { curl -fsSL "$1"; }
+elif command -v wget >/dev/null 2>&1; then
+  download() { wget -q "$1" -O "$2"; }
+  read_url() { wget -q "$1" -O -; }
+else
+  fail "neither curl nor wget is available"
+fi
+
+if [ -z "${VERSION}" ]; then
+  log "Looking up the latest PartCAD release..."
+  # Parsed with sed rather than with a JSON tool: `jq` is exactly the kind of
+  # prerequisite this installer exists to avoid.
+  VERSION="$(read_url "https://api.github.com/repos/${REPOSITORY}/releases/latest" |
+    sed -n 's/.*"tag_name" *: *"\([^"]*\)".*/\1/p' | head -n 1)"
+  [ -n "${VERSION}" ] || fail "could not determine the latest release of ${REPOSITORY}"
+fi
+
+ARCHIVE="partcad-${VERSION}-${PLATFORM}.tar.gz"
+: "${BASE_URL:=https://github.com/${REPOSITORY}/releases/download/${VERSION}}"
+ARCHIVE_URL="${BASE_URL}/${ARCHIVE}"
+
+TMP_DIR="$(mktemp -d)"
+cleanup() { rm -rf "${TMP_DIR}"; }
+trap cleanup EXIT INT TERM
+
+log "Downloading PartCAD ${VERSION} for ${PLATFORM}..."
+log "  ${ARCHIVE_URL}"
+download "${ARCHIVE_URL}" "${TMP_DIR}/${ARCHIVE}" || fail "download failed.
+       There may be no build of ${VERSION} for ${PLATFORM}. See
+       https://github.com/${REPOSITORY}/releases for what is available."
+
+# The download itself is authenticated by HTTPS; the checksum is here to catch
+# a truncated or corrupted transfer, so a machine without a checksum tool gets
+# a warning rather than a refusal.
+if download "${ARCHIVE_URL}.sha256" "${TMP_DIR}/${ARCHIVE}.sha256" 2>/dev/null; then
+  if command -v sha256sum >/dev/null 2>&1; then
+    (cd "${TMP_DIR}" && sha256sum -c "${ARCHIVE}.sha256" >/dev/null) ||
+      fail "checksum mismatch, the download is corrupted"
+    log "Checksum verified."
+  elif command -v shasum >/dev/null 2>&1; then
+    (cd "${TMP_DIR}" && shasum -a 256 -c "${ARCHIVE}.sha256" >/dev/null) ||
+      fail "checksum mismatch, the download is corrupted"
+    log "Checksum verified."
+  else
+    warn "no sha256 tool found, skipping checksum verification"
+  fi
+else
+  warn "no checksum published next to the archive, skipping verification"
+fi
+
+###############################################  INSTALL  ####################################################
+
+log "Unpacking..."
+tar -xzf "${TMP_DIR}/${ARCHIVE}" -C "${TMP_DIR}"
+[ -x "${TMP_DIR}/partcad/pc" ] || fail "the archive does not look like a PartCAD bundle"
+
+TARGET="${INSTALL_DIR}/${VERSION}"
+mkdir -p "${INSTALL_DIR}"
+# Replacing an existing copy of the same version: move the old one aside first,
+# so a failure here cannot leave a half-deleted installation behind.
+if [ -e "${TARGET}" ]; then
+  rm -rf "${TARGET}.old"
+  mv "${TARGET}" "${TARGET}.old"
+fi
+mv "${TMP_DIR}/partcad" "${TARGET}"
+rm -rf "${TARGET}.old"
+
+mkdir -p "${BIN_DIR}"
+for command_name in pc partcad; do
+  link="${BIN_DIR}/${command_name}"
+  if [ -e "${link}" ] && [ ! -L "${link}" ]; then
+    warn "${link} exists and is not a symlink, leaving it alone.
+         The standalone command is at ${TARGET}/${command_name}."
+    continue
+  fi
+  ln -sf "${TARGET}/${command_name}" "${link}"
+done
+
+log ""
+log "PartCAD ${VERSION} is installed in ${TARGET}."
+
+case ":${PATH}:" in
+*":${BIN_DIR}:"*)
+  log "Run 'pc --help' to get started."
+  ;;
+*)
+  log ""
+  log "${BIN_DIR} is not on your PATH. Add it, for example:"
+  log ""
+  log "    echo 'export PATH=\"${BIN_DIR}:\$PATH\"' >> ~/.profile"
+  log "    export PATH=\"${BIN_DIR}:\$PATH\""
+  log ""
+  log "Then run 'pc --help' to get started."
+  ;;
+esac
+
+log ""
+log "PartCAD runs CAD scripts in a sandbox it builds with conda, and clones"
+log "package repositories with git. Install conda and git to use those parts;"
+log "'pc healthcheck' reports what is missing."

--- a/partcad-cli/src/partcad_cli/click/command.py
+++ b/partcad-cli/src/partcad_cli/click/command.py
@@ -22,7 +22,16 @@ from partcad_cli.click.cli_context import CliContext
 global cli_span
 cli_span: pc.telemetry.trace.Span = None
 
-locale.setlocale(locale.LC_ALL, "en_US.UTF-8")
+try:
+    locale.setlocale(locale.LC_ALL, "en_US.UTF-8")
+except locale.Error:
+    # A machine that carries no en_US.UTF-8 locale must not fail before the
+    # first command runs. Minimal container images and the bare machines the
+    # standalone bundle targets frequently have only "C" generated.
+    try:
+        locale.setlocale(locale.LC_ALL, "C.UTF-8")
+    except locale.Error:
+        pass
 
 if True:
     # IMPORTANT:

--- a/partcad/src/partcad/utils.py
+++ b/partcad/src/partcad/utils.py
@@ -94,6 +94,12 @@ def is_editable_install(module):
     Returns:
         True if the module is from an editable install, False otherwise.
     """
+    # A PyInstaller bundle carries no site-packages at all, so the heuristics
+    # below would call every frozen module editable. It is the opposite: the
+    # code was frozen at build time and cannot be edited in place.
+    if getattr(sys, "frozen", False):
+        return False
+
     if not hasattr(module, "__file__"):
         return False  # Built-in or dynamically generated modules
 

--- a/partcad/src/partcad/wrappers/wrapper_common.py
+++ b/partcad/src/partcad/wrappers/wrapper_common.py
@@ -25,7 +25,15 @@ def handle_input():
         sys.stderr.write("Usage: %s <path>\n" % sys.argv[0])
         sys.exit(1)
 
-    locale.setlocale(locale.LC_ALL, "en_US.UTF-8")
+    try:
+        locale.setlocale(locale.LC_ALL, "en_US.UTF-8")
+    except locale.Error:
+        # Same fallback as the CLI: the sandbox interpreter inherits the host's
+        # locales, and a bare machine may have only "C" generated.
+        try:
+            locale.setlocale(locale.LC_ALL, "C.UTF-8")
+        except locale.Error:
+            pass
 
     # Handle the input
     # - Comand line parameters


### PR DESCRIPTION
## Copilot Summary

Adds a second build artifact next to the Python wheels: a **standalone PyInstaller bundle** that carries its
own interpreter, for users who have no Python installed and no interest in maintaining an environment for one.

```shell
curl -fsSL https://raw.githubusercontent.com/partcad/partcad/main/install.sh | sh
```

That downloads the bundle for the machine from the latest GitHub release, verifies its checksum, unpacks it
into `~/.local/share/partcad/<version>`, and links `pc` and `partcad` into `~/.local/bin`. No `sudo`, no
Python, nothing else on the system touched.

### What is here

| | |
| --- | --- |
| `dev-tools/pyinstaller/partcad.spec` | The interesting file: it names everything PyInstaller cannot discover on its own, with the reason for each entry. |
| `dev-tools/pyinstaller/build.sh` | Install → pre-flight import check → freeze → smoke test → archive + `.sha256`. |
| `install.sh` | POSIX `sh` installer: platform detection, checksum verification, symlinks, `--uninstall`. |
| `.github/workflows/build-standalone.yml` | Builds linux-x86_64 / macos-arm64 / windows-x86_64, then **installs and runs what it built**. |
| `.github/workflows/deploy.yml` | Calls the above and attaches the archives to the same release as the wheels. |
| `docs/source/installation.rst` | User documentation: install, options, upgrade/uninstall, development builds, Windows, prerequisites. |

Freezing replaces the *installation*, not the architecture. PartCAD still runs CAD scripts in a conda sandbox
it provisions itself, and still clones packages with `git`; both stay external prerequisites exactly as they
are for the wheels, and `pc healthcheck` reports what is missing. That is also why the wrappers ship as *data*
rather than as frozen modules — they are handed to that other interpreter by path.

### Releases

`deploy.yml` calls the standalone workflow, checks that an archive and a checksum arrived for every platform,
and uploads them to the release it creates. The release job blocks on the bundle build on purpose: a release
carrying the wheels but not the bundles is a release `install.sh` cannot install. Asset names are
`partcad-<version>-<os>-<arch>.tar.gz` (`.zip` on Windows), and the version comes from
`partcad/src/partcad/__init__.py`, which `bump-my-version` keeps equal to the release tag — which is what makes
the URL `install.sh` builds resolve.

### Verified

A real bundle was built and exercised from a clean directory, not just built:

- `pc version`, `pc init`, `pc list` (the dynamic subcommand loader), `pc healthcheck`
- `pc lint` — the bundled `ruff` reported a genuine syntax error
- both AI SDKs importing (frozen bundles cannot be extended with pip, so the `ai` and `lint` extras are built in)
- `pc export -t stl` on the STEP example: a full 19MB STL through the conda sandbox
- `pc inspect` tessellating through `ocp_vscode`
- `install.sh` install → run → uninstall round trip against the produced archive
- `sphinx-build -n -W` clean, `shellcheck` clean, pre-commit hooks pass, unit tests 303 passed / 20 skipped

That exercise caught one real defect. Built on Python 3.10, `ocp_vscode` collects *zero* modules (it needs
3.11+), and PyInstaller happily produced a complete-looking bundle that crashed on `pc inspect`. Hence the
pre-flight import check in `build.sh`, which fails the build instead, and the CI job that installs and runs
the artifact.

### Notes

- **Size**: ~780MB unpacked, ~250MB compressed. Most of it is the OpenCASCADE kernel, which the wheels also
  pull down, just at `pip install` time. ~130MB of unreachable payload (Google API discovery documents, `jedi`)
  is trimmed in the spec.
- **Platforms**: no linux-arm64 (`cadquery-ocp` 7.7.2 publishes no aarch64 Linux wheel), no macos-x86_64 (it
  needs `macos-13`, which never starts on the current runner plan — see the note in `test.yml`).
- **Build interpreter**: 3.11 or 3.12. PartCAD still supports 3.10, but `ocp_vscode` does not import there.
- Two behaviour fixes the frozen build needs, both harmless to the wheels: `is_editable_install()` no longer
  calls frozen modules editable (it was tagging production telemetry as `dev`), and the hard
  `setlocale(en_US.UTF-8)` at start-up falls back to `C.UTF-8` — bare machines, which is exactly who this
  bundle is for, often have only `C` generated.
- CI for this workflow is path-filtered, so it does not add ~500MB of OpenCASCADE downloads to unrelated pull
  requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
