### PR TITLE
fix(cli): stabilize commands that crashed instead of failing cleanly

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,13 @@ poetry install        # installs partcad + partcad-cli in editable mode
 The project virtualenv is not auto-activated, and `pytest`, `pc`, and `partcad` are **not** on `PATH` — prefix
 project commands with `poetry run`.
 
+Pass the global `--no-ansi` flag whenever `pc` is run non-interactively — in scripts, in batch jobs, and
+especially when an LLM agent parses the output. Without it, `pc` draws animated ANSI progress bars whose control
+characters corrupt captured output; with it, output is plain text with `INFO:`/`ERROR:` prefixes. Note that
+`--no-ansi` routes those logs to **stderr** (plain `logging`), whereas the default ANSI renderer writes to
+**stdout** — so capture both streams (`2>&1`) when parsing. The flag is global and goes before the subcommand:
+`poetry run pc --no-ansi info`.
+
 Note that `poetry.toml` sets `in-project = true`, so the virtualenv lives at `./.venv` inside the bind-mounted
 workspace and is shared between host and container. Running `poetry` on the host after running it in the
 container (or vice versa) makes each side rebuild `.venv`, because the interpreter paths baked into it are only

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -473,7 +473,7 @@ To test the Python core module using the VSCode plugin, click the `Restart PartC
 
   .. code-block:: text
 
-      ERROR: Failed to clone repo https://github.com/openvmp/partcad-index.git after 0 retries
+      ERROR: Failed to clone repo https://github.com/partcad/partcad-index.git after 0 retries
 
   then you are likely to have Git configured to use SSH creds to access GitHub,
   while the SSH creds are not available in the Dev container.

--- a/docs/source/use_cases.rst
+++ b/docs/source/use_cases.rst
@@ -55,7 +55,7 @@ The command line tools are the easiest way to browse parts:
     pc init
 
     # List all available packages
-    pc list
+    pc list packages
 
     # List all sketches in all available packages
     pc list sketches -r

--- a/examples/feature_monorepo/partcad.yaml
+++ b/examples/feature_monorepo/partcad.yaml
@@ -4,7 +4,7 @@ dependencies:
   pub:
     onlyInRoot: True
     type: git
-    url: https://github.com/openvmp/partcad-index.git
+    url: https://github.com/partcad/partcad-index.git
 
 parts:
   # This is a degenerate case pointing inside a child package, for testing purposes only.

--- a/examples/partcad.yaml
+++ b/examples/partcad.yaml
@@ -19,5 +19,5 @@ dependencies:
   pub:
     onlyInRoot: true
     type: git
-    url: https://github.com/openvmp/partcad-index.git
+    url: https://github.com/partcad/partcad-index.git
   # NOTE: The subdirectories automatically become dependencies of the "local" type

--- a/features/ai/regenerate.feature
+++ b/features/ai/regenerate.feature
@@ -1,0 +1,17 @@
+@cli @pc-ai-regenerate
+Feature: `pc ai regenerate` command
+
+  Background: Initialize sandbox
+    Given I am in "/tmp/sandbox/behave" directory
+    And I have temporary $HOME in "/tmp/sandbox/home"
+
+  @pc-ai-regenerate
+  Scenario: `pc ai regenerate` without an object reports a clear error without crashing
+    Given a file named "partcad.yaml" with content:
+      """
+      desc: A sample PartCAD package
+      """
+    When I run "pc ai regenerate"
+    Then the command should exit with a non-zero status code
+    And STDOUT should contain "No object specified"
+    And STDERR should not contain "Traceback"

--- a/features/info.feature
+++ b/features/info.feature
@@ -134,6 +134,31 @@ Feature: `pc info` command
     When I run "pc info test"
     Then the command should exit with a status code of "0"
     And STDOUT should contain "Path: '//'"
+
+  @success @pc-info
+  Scenario: `pc info` without an object shows the current package
+    Given a file named "partcad.yaml" with content:
+      """
+      desc: A sample PartCAD package
+      parts:
+        cube:
+          type: cadquery
+          path: cube.py
+      """
+    And a file named "cube.py" with content:
+      """
+      import cadquery as cq
+
+      if __name__ != "__cqgi__":
+          from cq_server.ui import ui, show_object
+
+      shape = cq.Workplane("front").box(10, 10, 10)
+      show_object(shape)
+      """
+    When I run "pc info"
+    Then the command should exit with a status code of "0"
+    And STDOUT should contain "Path: '//'"
+    And STDOUT should contain "sample PartCAD package"
 # And STDOUT should contain "cube" in the parts list
 # And STDOUT should contain "cylinder" in the parts list
 # And STDOUT should contain valid location coordinates

--- a/partcad-cli/src/partcad_cli/click/command.py
+++ b/partcad-cli/src/partcad_cli/click/command.py
@@ -533,10 +533,13 @@ def cli(ctx: click.Context, verbose: bool, quiet: bool, no_ansi: bool, path: str
                 exc.exit_code = 2
                 raise exc from e
             except Exception as e:
-                import traceback
-
                 pc.logging.error(e)
-                traceback.print_exc()
+                # Keep the traceback for troubleshooting, but do not dump it at
+                # the user during normal operation.
+                if logging.getLogger("partcad").isEnabledFor(logging.DEBUG):
+                    import traceback
+
+                    traceback.print_exc()
                 raise click.Abort from e
 
         # Pass everything the commands might need through the context object
@@ -578,6 +581,13 @@ def main():
         cli()
     except Exception as e:
         sentry_sdk.capture_exception(e)
+        # When a clean error was already reported to the user (for example a
+        # repository that could not be cloned), do not additionally dump a
+        # traceback. Unexpected failures stay loud so that real bugs are not
+        # hidden, and the traceback remains available under '-v'.
+        if pc.logging.had_errors and not logging.getLogger("partcad").isEnabledFor(logging.DEBUG):
+            pc.logging.error(str(e) if str(e) else type(e).__name__)
+            sys.exit(1)
         raise e
 
 

--- a/partcad-cli/src/partcad_cli/click/commands/ai/regenerate.py
+++ b/partcad-cli/src/partcad_cli/click/commands/ai/regenerate.py
@@ -64,6 +64,10 @@ def cli(cli_ctx: CliContext, sketch, interface, assembly, scene, package, object
             )
             return
 
+        if object is None:
+            pc.logging.error("No object specified. Provide a part to regenerate.")
+            return
+
         package, object = pc.utils.resolve_resource_path(ctx.get_current_project_path(), object)
 
         with pc.logging.Process("Regenerate", package):

--- a/partcad-cli/src/partcad_cli/click/commands/export.py
+++ b/partcad-cli/src/partcad_cli/click/commands/export.py
@@ -111,7 +111,7 @@ def cli(
 
             for package in packages:
                 if not object is None:
-                    package, object = pc.utils.resolve_resource_path(ctx.get_current_project_path() + package, object)
+                    package, object = pc.utils.resolve_resource_path(package, object)
 
                 if object is None:
                     # Render all parts and assemblies configured to be auto-rendered in this project

--- a/partcad-cli/src/partcad_cli/click/commands/info.py
+++ b/partcad-cli/src/partcad_cli/click/commands/info.py
@@ -76,6 +76,19 @@ def cli(cli_ctx: CliContext, package, interface, assembly, sketch, scene, object
                 k, v = kv.split("=")
                 param_dict[k] = v
 
+        # Without an object name, show information about the current package
+        # (or the one selected via '-P') instead of crashing on a missing name.
+        if object is None:
+            package_name = ctx.resolve_package_path(package)
+            package_obj = ctx.get_project(package_name)
+            if not package_obj:
+                pc.logging.error(f"Package {package_name} is not found")
+                return
+            info = package_obj.info()
+            for k, v in info.items():
+                pc.logging.info(f"INFO: {k}: {pformat(v)}")
+            return
+
         package, object = pc.utils.resolve_resource_path(ctx.get_current_project_path(), object)
         path = f"{package}:{object}"
 

--- a/partcad-cli/src/partcad_cli/click/commands/inspect.py
+++ b/partcad-cli/src/partcad_cli/click/commands/inspect.py
@@ -88,6 +88,12 @@ def cli(cli_ctx: CliContext, context, verbal, package, interface, assembly, sket
                     k, v = kv.split("=")
                     param_dict[k] = v
 
+            if object is None:
+                pc.logging.error(
+                    "No object specified. Provide a part, assembly, sketch, interface, or scene to inspect."
+                )
+                return
+
             package, object = pc.utils.resolve_resource_path(ctx.get_current_project_path(), object)
             path = f"{package}:{object}"
 

--- a/partcad-cli/src/partcad_cli/click/commands/render.py
+++ b/partcad-cli/src/partcad_cli/click/commands/render.py
@@ -115,7 +115,7 @@ def cli(
 
             for package in packages:
                 if not object is None:
-                    package, object = pc.utils.resolve_resource_path(ctx.get_current_project_path() + package, object)
+                    package, object = pc.utils.resolve_resource_path(package, object)
 
                 if object is None:
                     # Render all parts and assemblies configured to be auto-rendered in this project

--- a/partcad/src/partcad/context.py
+++ b/partcad/src/partcad/context.py
@@ -959,7 +959,8 @@ class Context(project_config.Configuration):
         if not self.option_create_dirs:
             return
         path = os.path.dirname(filename)
-        os.makedirs(path)
+        if path:
+            os.makedirs(path, exist_ok=True)
 
     def get_all_tests(self):
         return all_tests(self.user_config.threads_max)

--- a/partcad/src/partcad/project.py
+++ b/partcad/src/partcad/project.py
@@ -250,6 +250,22 @@ class Project(project_config.Configuration):
     #             self.path + "/" + self.config_obj["cover"]["package"]
     #         ).get_cover()
 
+    def info(self) -> dict:
+        """Return package-level information (name, description, URLs).
+
+        Mirrors the object factories' ``info()`` so that ``pc info`` can render
+        a package the same way it renders parts, sketches and assemblies. It
+        intentionally does not enumerate the package's objects.
+        """
+        info = {"Path": self.name}
+        if "url" in self.config_obj and self.config_obj["url"] is not None:
+            info["Url"] = self.config_obj["url"]
+        if "importUrl" in self.config_obj and self.config_obj["importUrl"] is not None:
+            info["ImportUrl"] = self.config_obj["importUrl"]
+        if self.desc:
+            info["Desc"] = self.desc
+        return info
+
     def matches(self, keyword: str) -> bool:
         if not keyword:
             return False

--- a/partcad/src/partcad/shape.py
+++ b/partcad/src/partcad/shape.py
@@ -164,6 +164,16 @@ class Shape(ShapeConfiguration):
     def get_cacheable(self) -> bool:
         return self.cacheable and not self.get_cache_dependencies_broken()
 
+    async def get_summary_async(self, project=None):
+        # Return a manually configured summary if present; otherwise None so
+        # that AI-backed shapes (ShapeWithAi) can generate one via super().
+        if "summary" in self.config and self.config["summary"] is not None:
+            return self.config["summary"]
+        return None
+
+    def get_summary(self, project=None):
+        return asyncio.run(self.get_summary_async(project))
+
     def get_async_lock(self) -> asyncio.Lock:
         if not hasattr(self.tls, "async_shape_locks"):
             self.tls.async_shape_locks = {}
@@ -685,15 +695,18 @@ class Shape(ShapeConfiguration):
                 pc_logging.error(f"Cannot render '{self.name}': shape is empty")
                 return
 
-            if project is not None:
-                project.ctx.ensure_dirs_for_file(filepath)
-
             formats_to_render = [format_name] if format_name else list(WRAPPER_FORMATS.keys())
 
             for format in formats_to_render:
                 file_extension = PART_EXTENSION_MAPPING.get(format, format)
                 render_opts, final_filepath = self.render_getopts(format, f".{file_extension}", project, filepath)
                 final_filepath = os.path.abspath(final_filepath)
+                # Create the output directory for the resolved path. Use
+                # 'final_filepath' (the incoming 'filepath' is None when called
+                # from Project.render_async, which broke '--create-dirs' with a
+                # TypeError) and the 'ctx' passed in, so direct callers without a
+                # project still get '--create-dirs'.
+                ctx.ensure_dirs_for_file(final_filepath)
                 pc_logging.debug(f"Rendering: {self.project_name}:{self.name} for format '{format}'")
 
                 wrapper_path = wrapper.get(f"render_{format}.py")


### PR DESCRIPTION
## Summary

Several documented CLI commands crashed with raw Python tracebacks. This validates the documented CLI surface — `docs/source/*.rst` and `pc <cmd> --help`, both treated as the source of truth for intended behaviour — against the `./examples` testbed, and fixes the **code** to match the docs. Everything was exercised with `pc --no-ansi`.

## Fixes

| Command | Symptom | Root cause |
|---|---|---|
| `pc info` / `pc inspect` (no object) | `TypeError: argument of type 'NoneType' is not iterable` | the optional `OBJECT` was passed straight into `resolve_resource_path()` |
| `pc inspect -V` (part/assembly/sketch) | `AttributeError: 'super' object has no attribute 'get_summary_async'` | #382 removed `Shape.get_summary_async()`/`get_summary()`, which `ShapeWithAi` still calls via `super()` |
| `pc export` / `pc render <obj>` | `AttributeError: 'NoneType' object has no attribute 'render'` | `get_current_project_path() + package` concatenated an already-absolute package path, so `get_project()` returned `None` |
| `pc export` / `pc render --create-dirs` | `TypeError: expected str, bytes or os.PathLike object, not NoneType` | `ensure_dirs_for_file()` was called before the output path was resolved (it is always `None` there) |
| `pc ai regenerate` (no object) | crash | missing no-object guard |
| any git clone failure | raw traceback | the exception reached `main()` unhandled |

Behavioural notes:

- `pc info` with no object now prints information about the **current package** (via a new `Project.info()`) instead of crashing. It deliberately does not enumerate the package's objects.
- `pc inspect` and `pc ai regenerate` with no object report a clean error — a package cannot be visualised or regenerated.
- Clone failures print a clean one-line error **only when a clean error was already reported**. Unexpected failures stay loud so real bugs are not hidden, and `-v` always restores the full traceback.

## Also in this change

- Point the public index at `github.com/partcad/partcad-index` in the examples (the old `openvmp/…` URL only still resolves through a GitHub redirect).
- `docs/source/use_cases.rst`: `pc list packages` lists packages; bare `pc list` prints group help.
- `AGENTS.md`: document running `pc --no-ansi` for non-interactive and agent use (plain text, logs on stderr, versus the ANSI renderer writing to stdout).

## Testing

- `pytest partcad partcad-cli`: **303 passed, 20 skipped, 0 failed**.
- `behave` (full suite): 145 passed / 19 failed, reconciled against a stashed pristine tree:
  - **15 flaky** — pass when re-run as a subset (state pollution over the 106-minute full run).
  - **4 pre-existing** — fail identically without this branch.
  - **1 genuine regression**, caught during review and fixed here (`pc.feature:109`; an earlier version of the `main()` handler swallowed internal errors).
- New scenario in `features/info.feature`; `features/ai/regenerate.feature` populated.
- Every fixed command re-verified against `./examples`: exports/renders produce files, no tracebacks.

## Known pre-existing issues (deliberately not addressed here)

- `command.py` passes `param=<str>` to `click.BadParameter`, which expects a `Parameter`. Click then raises `'str' object has no attribute 'get_error_hint'`, so the intended "Invalid configuration file" message never renders. Fixing it would also flip the exit code (1 → 2) and break `pc.feature:109`'s assertion.
- `adhoc/convert/part.feature:114/119/124` assert click usage errors on STDOUT, but click writes them to STDERR.
- `test_project_config_template_override` and `test_file_url_part_1` are racy under `pytest -n 4` (shared context and `~/.partcad` cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
