### PR TITLE
fix(behave): tolerate missing en_US locale and non-UTF-8 output

### DIFF
--- a/features/__init__.py
+++ b/features/__init__.py
@@ -2,4 +2,14 @@ import locale
 import os
 
 os.environ["PARTCAD_ROOT"] = os.getcwd()
-locale.setlocale(locale.LC_ALL, "en_US.UTF-8")
+
+try:
+    locale.setlocale(locale.LC_ALL, "en_US.UTF-8")
+except locale.Error:
+    # Same fallback as the CLI and the wrappers: the test runner must not fail
+    # at import time on a machine that has only "C" generated, which is the
+    # common case for the minimal images CI runs behave in.
+    try:
+        locale.setlocale(locale.LC_ALL, "C.UTF-8")
+    except locale.Error:
+        pass

--- a/features/steps/partcad-cli/commands/version.py
+++ b/features/steps/partcad-cli/commands/version.py
@@ -126,7 +126,9 @@ def step_impl(context: Context) -> None:
     partcad_path = shutil.which("partcad")
     if not partcad_path:
         raise RuntimeError("partcad executable not found in PATH")
-    cli_version = subprocess.check_output([partcad_path, "version"], stderr=subprocess.STDOUT).decode()
+    cli_version = subprocess.check_output([partcad_path, "version"], stderr=subprocess.STDOUT).decode(
+        "utf-8", errors="replace"
+    )
     package_version = partcad.__version__
 
     assert package_version in cli_version, (

--- a/features/steps/run.py
+++ b/features/steps/run.py
@@ -49,6 +49,7 @@ def run(context: Context, command: str):
         cwd=cwd,
         env=env,
         encoding="utf-8",
+        errors="replace",
     )
     end_time = time.time()
     context.duration = end_time - start_time


### PR DESCRIPTION
## What

Makes the `behave` harness robust to two environment assumptions that hold on developer machines but not on the minimal images CI runs `behave` in (nor on the bare machines the standalone PyInstaller bundle targets):

1. **`features/__init__.py`** forced `setlocale(LC_ALL, "en_US.UTF-8")` at import time. On an image where only the `C` locale is generated this raises `locale.Error` *before any scenario runs*, taking down the whole suite. It now falls back to `C.UTF-8` and then to a no-op — the same pattern already used in `partcad_cli/click/command.py` and `partcad/wrappers/wrapper_common.py`.
2. **`features/steps/run.py`** decoded subprocess output as strict UTF-8, so a single non-UTF-8 byte in a command's output crashed the step instead of the command under test. Now decodes with `errors="replace"`.
3. **`features/steps/partcad-cli/commands/version.py`** decoded `partcad version` output with a bare `.decode()`; same `errors="replace"` treatment.

## Why

This completes an `en_US.UTF-8` → `C.UTF-8` sweep: the CLI and wrappers already carry the fallback; the test harness was the last place still assuming the locale exists. Items 2–3 are the reusable, low-risk parts salvaged from the exploratory encoding work in #401 (which is otherwise being closed).

## Testing

- `pytest partcad partcad-cli` — passes (via the pre-commit gate).
- `behave` full suite on this branch — no new failures introduced; the pre-existing failures are unrelated (missing SSH key locally, and a separate stream-assertion bug addressed in a follow-up PR).

Note: item 1's fallback path is a no-op on images that *do* have `en_US.UTF-8` (including the dev container), so it's verified by inspection and by the suite not regressing rather than by exercising the fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)