### PR TITLE
fix(behave): match adhoc-convert usage errors on combined STDOUT+STDERR

### DIFF
--- a/features/adhoc/convert/part.feature
+++ b/features/adhoc/convert/part.feature
@@ -114,17 +114,17 @@ Feature: `pc adhoc convert` command
   Scenario: Fail on unknown input type
     When I run "pc adhoc convert part test.stl test.step --input unknown --output step"
     Then the command should exit with a status code of "2"
-    And STDOUT should contain "Invalid value for '--input'"
+    And OUTPUT should contain "Invalid value for '--input'"
 
   Scenario: Fail on unknown output type
     When I run "pc adhoc convert part test.stl test.step --input stl --output unknown"
     Then the command should exit with a status code of "2"
-    And STDOUT should contain "Invalid value for '--output'"
+    And OUTPUT should contain "Invalid value for '--output'"
 
   Scenario: Fail when input file is missing
     When I run "pc adhoc convert part missing.stl test.step"
     Then the command should exit with a status code of "2"
-    And STDOUT should contain "Path 'missing.stl' does not exist."
+    And OUTPUT should contain "Path 'missing.stl' does not exist."
 
   Scenario: Fail on empty file
     Given a file named "empty.stl" with content:

--- a/features/steps/partcad-cli/commands/version.py
+++ b/features/steps/partcad-cli/commands/version.py
@@ -62,6 +62,21 @@ def step_impl(context, substring):
         raise AssertionError(f"Expected '{substring}' in STDERR, but it was not found")
 
 
+@then("OUTPUT should contain '{substring}'")
+@then('OUTPUT should contain "{substring}"')
+def step_impl(context, substring):
+    # Matches against STDOUT and STDERR combined. rich_click routes click
+    # usage errors to different streams depending on the environment (STDOUT
+    # under the conda env CI runs behave in, STDERR under the poetry dev
+    # container), so asserting a single stream is environment-fragile.
+    substring = expandvars(substring, context)
+    combined = strip_ansi(context.result.stdout) + "\n" + strip_ansi(context.result.stderr)
+    logging.debug(f"STDOUT: {strip_ansi(context.result.stdout)}")
+    logging.debug(f"STDERR: {strip_ansi(context.result.stderr)}")
+    if substring not in combined:
+        raise AssertionError(f"Expected '{substring}' in STDOUT or STDERR, but it was not found")
+
+
 @then('STDOUT should not contain "{substring}" with path')
 def step_impl(context, substring):
     substring = expandvars(substring, context)


### PR DESCRIPTION
## What

Three scenarios in `features/adhoc/convert/part.feature` assert that a click parameter-validation error appears in the CLI output:

- `Fail on unknown input type` → `"Invalid value for '--input'"`
- `Fail on unknown output type` → `"Invalid value for '--output'"`
- `Fail when input file is missing` → `"Path 'missing.stl' does not exist."`

They pinned the message to a single stream (`STDOUT`). But **`rich_click` routes click usage errors to different streams depending on the environment**: to **STDOUT** under the conda env CI runs `behave` in, and to **STDERR** under the poetry-based dev container. So a single-stream assertion passes in one environment and fails in the other — which is exactly what surfaced here (the original `STDOUT` form was green in CI but failed in the dev container; a naive flip to `STDERR` did the reverse).

This adds an `OUTPUT should contain` step that matches **STDOUT and STDERR combined** (ANSI-stripped) and uses it for the three scenarios. It still verifies the CLI exits `2` with the correct message, and it is robust across both environments.

## Why it went unnoticed

The scenarios were introduced with #396. The `behave` pre-commit hook is in the dev container `SKIP` list, so a locally-run commit never exercised them; and CI happened to route to the stream the assertion expected, so CI stayed green.

## Testing

```
behave features/adhoc/convert/part.feature -n "Fail on unknown input type" \
  -n "Fail on unknown output type" -n "Fail when input file is missing"
→ 3 scenarios passed, 0 failed        # dev container (STDERR routing)
```

CI on this branch exercises the STDOUT routing; the combined check covers both.

> Note: the branch is still named `…-stderr` from the first approach; kept as-is to avoid a PR retarget. The final fix is combined-stream, per the title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)