### PR TITLE
ci(standalone): run the Examples suites against the PyInstaller bundle

### DIFF
--- a/.github/workflows/build-standalone.yml
+++ b/.github/workflows/build-standalone.yml
@@ -162,3 +162,127 @@ jobs:
             --bin-dir "${HOME}/partcad-bin"
           test ! -e "${HOME}/partcad-bin/pc"
           test ! -d "${HOME}/partcad-standalone"
+
+  # The wheel-based "Examples (PartCAD)" and "Examples (All)" jobs in test.yml,
+  # cloned to run the same commands through the *bundled* `pc` rather than
+  # `python -m partcad_cli ...`. This is the end-to-end check the build's own
+  # smoke test cannot be: it fetches a git dependency (through the bundle's
+  # libgit2, which nothing else here exercises), runs CAD scripts in the conda
+  # sandbox, and -- on Linux -- uses the OpenSCAD the bundle carries.
+  #
+  # Skipped on the release path (deploy.yml calls this workflow on a push to
+  # main) and in the merge queue, to keep those fast and off heavy integration
+  # tests; the deterministic build and install jobs above gate the release.
+  examples:
+    name: "Examples ${{ matrix.suite }} via bundle (${{ matrix.platform }})"
+    needs: build
+    if: >-
+      github.event_name == 'pull_request' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/devel')
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: linux-x86_64
+            suite: PartCAD
+            package: "//pub/examples/partcad"
+            render: true
+          - os: ubuntu-latest
+            platform: linux-x86_64
+            suite: All
+            package: "//pub/examples"
+            render: false
+          - os: macos-latest
+            platform: macos-arm64
+            suite: PartCAD
+            package: "//pub/examples/partcad"
+            render: true
+          - os: macos-latest
+            platform: macos-arm64
+            suite: All
+            package: "//pub/examples"
+            render: false
+    runs-on: ${{ matrix.os }}
+    # No conda cache and a sandbox built from scratch (cadquery-ocp is ~150MB),
+    # so this is slower than the cached wheel-based jobs in test.yml.
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v7
+
+      # PartCAD runs CAD scripts in a conda sandbox it provisions at runtime, so
+      # the bundle still needs conda/mamba on PATH -- the one host prerequisite
+      # it does not carry, exactly as for the wheels.
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          miniforge-version: 24.11.3-0
+          use-mamba: true
+          channels: conda-forge,defaults
+          # Only base is needed -- PartCAD creates its own sandbox env at
+          # runtime. No named env, which is the part of setup-all that is flaky
+          # enough to need continue-on-error.
+          auto-activate-base: true
+          activate-environment: ""
+
+      # The libraries the bundled OpenSCAD AppImage resolves from the host: it is
+      # not fully self-contained (see dev-tools/pyinstaller/build.sh). A desktop
+      # has these; a CI runner may not, so install them and let the examples use
+      # the bundled OpenSCAD.
+      - name: Install the bundled OpenSCAD's host libraries (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends \
+            libgl1 libx11-6 libxcb1 libfontconfig1 libfreetype6 libglib2.0-0 libharfbuzz0b
+
+      # macOS bundles carry no OpenSCAD (see build.sh), so the examples fall back
+      # to a host OpenSCAD there, exactly as the wheels do. Same install as the
+      # wheel-based jobs' setup-test action.
+      - name: Install OpenSCAD (macOS)
+        if: runner.os == 'macOS'
+        shell: bash -el {0}
+        run: |
+          which openscad \
+            || HOMEBREW_NO_AUTO_UPDATE=1 brew install -f openscad \
+            || ( \
+              rm /Users/"$USER"/Library/Caches/Homebrew/downloads/*--OpenSCAD-*.dmg \
+              && HOMEBREW_NO_AUTO_UPDATE=1 brew install -f openscad \
+            )
+
+      - name: Download the bundle
+        uses: actions/download-artifact@v8
+        with:
+          name: partcad-standalone-${{ matrix.platform }}
+          path: archives
+
+      - name: Install with install.sh
+        shell: bash -el {0}
+        run: |
+          version=$(sed -n 's/^__version__: str = "\(.*\)"$/\1/p' partcad/src/partcad/__init__.py)
+          sh install.sh \
+            --version "${version}" \
+            --base-url "file://${PWD}/archives" \
+            --install-dir "${HOME}/partcad-standalone" \
+            --bin-dir "${HOME}/partcad-bin"
+          # Put the bundled `pc` on PATH for the steps below.
+          echo "${HOME}/partcad-bin" >> "${GITHUB_PATH}"
+
+      - name: Healthcheck
+        shell: bash -el {0}
+        run: pc --no-ansi healthcheck
+
+      # The same commands the wheel-based Examples jobs run, through the bundled
+      # `pc`. No coverage: a frozen binary cannot be instrumented, and coverage
+      # of the shipped bundle is not meaningful. `cd examples` so the local
+      # package resolves as it does in test.yml.
+      - name: Run the ${{ matrix.suite }} examples through the bundle
+        shell: bash -el {0}
+        run: |
+          cd examples
+          pc --no-ansi list all -r ${{ matrix.package }}
+          pc --no-ansi --threads-max 4 test -r --package ${{ matrix.package }}
+          if [ "${{ matrix.render }}" = "true" ]; then
+            pc --no-ansi --threads-max 4 render -r --package ${{ matrix.package }}
+          fi


### PR DESCRIPTION
## Copilot Summary

Clones the wheel-based **Examples (PartCAD)** and **Examples (All)** jobs from `test.yml` and runs the same
`pc list / test / render` commands through the **PyInstaller bundle** instead of `python -m partcad_cli …`
under coverage. The new jobs live in `build-standalone.yml` and reuse the artifacts the `build` job already
produced (`needs: build`), on the two platforms `install.sh` supports: `linux-x86_64` and `macos-arm64`.

### Why

Until now nothing exercised the bundle against real packages. The standalone workflow only installed it and
ran `pc version` / `init` / `list` — none of which fetch a remote package, run a CAD script, or touch
OpenSCAD. These jobs close that gap and cover three paths that were frozen into the bundle but never run in
one:

- **libgit2** — the examples pull a git dependency (`partcad-index`); the git path had zero bundle coverage.
- **the conda sandbox** — provisioned at runtime by the frozen `pc` to run CAD scripts.
- **the bundled OpenSCAD** on Linux (macOS carries none, so a host OpenSCAD is installed there, as for the
  wheels).

### What's different from the wheel-based jobs

- **Install:** the bundle via `install.sh`, not `pip install` into a mamba env.
- **Invocation:** the bundled `pc`, not `python -m partcad_cli.click.command`.
- **No coverage:** a frozen binary can't be instrumented, and coverage of the shipped bundle isn't
  meaningful — so no `coverage run` and no codecov upload.
- **OpenSCAD:** from the bundle on Linux (the job installs the handful of host libraries the AppImage resolves
  — `libGL`/`libX11`/`libxcb`/fontconfig/freetype/glib/harfbuzz — since a CI runner may lack them); from
  Homebrew on macOS, where the bundle carries none.
- **conda/mamba** is still set up — the one host prerequisite the bundle does not carry, same as the wheels.

### Scope / cost

Four jobs (2 suites × 2 platforms, single Python — the bundle's). They run on pull requests, pushes to
`devel`, and `workflow_dispatch`, and are **skipped on the release path** (`deploy.yml` calls this workflow on
a push to `main`) and in the merge queue, so neither is gated on heavy integration tests — the deterministic
build and install jobs continue to gate the release. No conda cache and a from-scratch sandbox
(cadquery-ocp ≈150 MB) make these slower than the cached wheel-based jobs; `timeout-minutes: 60`.

### Verified before wiring the CI

Ran the exact commands against a freshly built bundle in the dev container:

- `pc list all -r //pub/examples/partcad` — fetched the git dependency through the bundle's libgit2 and listed
  84 parts / 12 assemblies (exit 0)
- `pc test` on a cadquery example — passed through the conda sandbox (exit 0)
- `pc test` on the openscad example — passed through the bundled OpenSCAD (exit 0)

So the paths these jobs depend on already work; the jobs make that a standing check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
