### PR TITLE
feat(git): recover from an ambient git config that blocks anonymous clones

### DIFF
--- a/partcad/src/partcad/healthcheck/stale_git_locks.py
+++ b/partcad/src/partcad/healthcheck/stale_git_locks.py
@@ -1,0 +1,79 @@
+#
+# PartCAD, 2025
+#
+# Licensed under Apache License, Version 2.0.
+#
+
+import glob
+import os
+
+from filelock import FileLock, Timeout
+
+from .tests import HealthCheckReport, HealthCheckTest
+from partcad.user_config import user_config
+
+
+class StaleGitLocksCheck(HealthCheckTest):
+    """Find git cache lock files that no running process holds.
+
+    PartCAD guards each cached git repository with a file lock so that two
+    processes never clone the same repository into the same directory at once.
+    The operating system releases the lock when the process exits, but the lock
+    file itself is left on disk. A lock file that no process holds is therefore
+    only clutter; this check finds those and offers to remove them. A lock a
+    running process still holds is left untouched.
+    """
+
+    def __init__(self):
+        super().__init__(
+            name="StaleGitLocks",
+            tags=["git", "lock", "cache"],
+            description="check for leftover git cache lock files that no running process holds",
+        )
+        self._git_dir = os.path.join(user_config.internal_state_dir, "git")
+        self._stale: list[str] = []
+
+    def auto_fixable(self) -> bool:
+        return True
+
+    def is_applicable(self) -> bool:
+        return os.path.isdir(self._git_dir)
+
+    def _is_unheld(self, lock_path: str) -> bool:
+        """Whether 'lock_path' is a lock file no process currently holds."""
+        lock = FileLock(lock_path, timeout=0)
+        try:
+            lock.acquire()
+        except Timeout:
+            # A running process holds it.
+            return False
+        lock.release()
+        return True
+
+    def test(self) -> HealthCheckReport:
+        self._stale = []
+        try:
+            for lock_path in sorted(glob.glob(os.path.join(self._git_dir, "*.lock"))):
+                if self._is_unheld(lock_path):
+                    self._stale.append(lock_path)
+                    self.findings.append(f"Stale git lock file: {lock_path}")
+        except Exception as e:
+            self.findings.append(f"Error checking git lock files: {e}")
+        return HealthCheckReport(self.name, self.findings)
+
+    def fix(self) -> bool:
+        removed_all = True
+        for lock_path in self._stale:
+            # Re-check that it is still unheld: a clone may have started since
+            # the test ran, and a live lock must never be removed.
+            if not self._is_unheld(lock_path):
+                removed_all = False
+                continue
+            try:
+                os.remove(lock_path)
+            except FileNotFoundError:
+                # Someone else already cleaned it up.
+                pass
+            except OSError:
+                removed_all = False
+        return removed_all

--- a/partcad/src/partcad/project_factory_git.py
+++ b/partcad/src/partcad/project_factory_git.py
@@ -13,12 +13,14 @@ import re
 import os
 import shutil
 import time
+import contextlib
 import threading
 from dataclasses import dataclass
 from urllib.parse import urlparse
 
 import pygit2
-from pygit2.enums import CheckoutStrategy, CredentialType, ReferenceType, ResetMode
+from filelock import FileLock
+from pygit2.enums import CheckoutStrategy, ConfigLevel, CredentialType, ReferenceType, ResetMode
 
 from .project_local import ProjectLocal
 from . import project_factory as pf
@@ -141,6 +143,32 @@ def is_retryable(error: Exception) -> bool:
     """Whether 'error' is a hiccup worth another attempt rather than an answer."""
     message = str(error)
     return any(re.search(pattern, message, re.IGNORECASE) for pattern in git_error_patterns)
+
+
+# An authentication or credential failure, as opposed to a transient network
+# problem (is_retryable) or a definitive answer such as a 404 or a missing ref.
+# These are what a 'url.*.insteadOf' rewrite in the ambient git config produces
+# when it sends an anonymous clone to a transport whose credentials are not
+# available here, so they are the failures worth retrying with that config
+# ignored. A repository that is genuinely gone answers differently and must not
+# match: ignoring the config cannot make a missing repository appear.
+auth_error_patterns = [
+    r"authentication is required",
+    r"authentication required",
+    r"no credentials",
+    r"unsupported credentials",
+    r"failed to authenticate",
+    r"permission denied",
+    r"too many redirects or authentication replays",
+    # HTTP unauthorized/forbidden, worded the way libgit2 words a bad status
+    r"unexpected http status code: 40[13]",
+]
+
+
+def is_auth_failure(error: Exception) -> bool:
+    """Whether 'error' is an authentication or credential failure."""
+    message = str(error)
+    return any(re.search(pattern, message, re.IGNORECASE) for pattern in auth_error_patterns)
 
 
 # A commit id, whole or abbreviated. Anything else is treated as a branch or
@@ -490,6 +518,74 @@ def get_cache_lock(hash):
     return lock
 
 
+# libgit2 reads the ambient git configuration (~/.gitconfig and the system
+# config) directly. A user's 'url.*.insteadOf' rewrite there can send an
+# anonymous clone to a transport whose credentials are not available here (an
+# https URL rewritten to ssh with no key in a container, for example). When a
+# clone has otherwise failed, PartCAD retries it once with these configuration
+# levels ignored, so the URL is used as written. Clearing them is a process-wide
+# libgit2 setting, so the retry must run with no clone that honors the ambient
+# config in flight, and the levels have to be restored afterwards.
+_AMBIENT_CONFIG_LEVELS = (ConfigLevel.SYSTEM, ConfigLevel.XDG, ConfigLevel.GLOBAL)
+
+
+class _AmbientConfigGuard:
+    """Coordinate the process-wide libgit2 config search path across threads.
+
+    The search path is a single process-wide libgit2 setting, so clearing it for
+    one clone would strip the ambient configuration from every clone running
+    beside it. Clones that honor the ambient config are therefore readers and
+    stay concurrent, while the fallback clone that clears the search path is the
+    writer: it waits until no reader is in flight, then blocks new readers until
+    it has restored the search path.
+
+    This coordinates threads within one process, which is all the search path
+    needs: it is process-local memory, so a separate process clearing its own
+    copy cannot affect this one. Cross-process safety of the shared cache on
+    disk is a different concern, handled by the per-repository file lock.
+    """
+
+    def __init__(self):
+        self._condition = threading.Condition()
+        self._readers = 0
+        self._writer = False
+
+    @contextlib.contextmanager
+    def honoring_ambient_config(self):
+        with self._condition:
+            while self._writer:
+                self._condition.wait()
+            self._readers += 1
+        try:
+            yield
+        finally:
+            with self._condition:
+                self._readers -= 1
+                if self._readers == 0:
+                    self._condition.notify_all()
+
+    @contextlib.contextmanager
+    def ignoring_ambient_config(self):
+        with self._condition:
+            while self._writer or self._readers > 0:
+                self._condition.wait()
+            self._writer = True
+        saved = {level: pygit2.settings.search_path[level] for level in _AMBIENT_CONFIG_LEVELS}
+        try:
+            for level in _AMBIENT_CONFIG_LEVELS:
+                pygit2.settings.search_path[level] = ""
+            yield
+        finally:
+            for level, path in saved.items():
+                pygit2.settings.search_path[level] = path
+            with self._condition:
+                self._writer = False
+                self._condition.notify_all()
+
+
+_ambient_config_guard = _AmbientConfigGuard()
+
+
 class GitImportConfiguration:
     def __init__(self):
         self.import_config_url = self.config_obj.get("url")
@@ -593,6 +689,29 @@ class ProjectFactoryGit(pf.ProjectFactory, GitImportConfiguration):
             inherited_config=self.inherited_config,
         )
 
+    def _clone_ignoring_ambient_config(self, repo_url, cache_path, clone_options, guard_path) -> bool:
+        """Retry a failed clone with the ambient git config ignored.
+
+        Returns True if the retry filled the cache. A False return leaves the
+        original failure for the caller to report, because ignoring the config
+        did not help.
+        """
+        pc_logging.warning(
+            "Clone of %s failed to authenticate; retrying with the ambient git config ignored",
+            self.import_config_url,
+        )
+        try:
+            with _ambient_config_guard.ignoring_ambient_config():
+                repo = self._clone_repo(repo_url, cache_path, clone_options)
+        except GIT_ERRORS:
+            return False
+        self.ctx.stats_git_ops += 1
+        after = self.import_revision if self.import_revision is not None else repo.head.target
+        with open(guard_path, "w") as f:
+            f.write(str(after))
+        pc_logging.info("Cloned %s with the ambient git config ignored", self.import_config_url)
+        return True
+
     def _clone_or_update_repo(self, repo_url, cache_dir=None):
         """
         Clones a Git repository to a local directory and keeps it up-to-date.
@@ -623,9 +742,17 @@ class ProjectFactoryGit(pf.ProjectFactory, GitImportConfiguration):
         cache_path = os.path.join(cache_dir, repo_hash)
         cache_lock = get_cache_lock(repo_hash)
 
+        # A file lock beside the cached copy serializes this repository across
+        # processes as well, not just across the threads the threading lock
+        # covers, so two 'pc' invocations never clone into the same directory at
+        # once. The lock file is released when the process exits but left on
+        # disk; the 'StaleGitLocks' healthcheck removes ones no process holds.
+        os.makedirs(cache_dir, exist_ok=True)
+        repo_file_lock = FileLock(os.path.join(cache_dir, repo_hash + ".lock"))
+
         guard_path = os.path.join(cache_path, ".partcad.git.cloned")
 
-        with cache_lock:
+        with cache_lock, repo_file_lock:
             attempt = 0
             # Bound every network operation below. Without this a stalled
             # remote hangs forever, and the retry loop never helps because a
@@ -650,13 +777,14 @@ class ProjectFactoryGit(pf.ProjectFactory, GitImportConfiguration):
 
                                 # If there is more than 1 remote branch, we have to
                                 # explicitly specify the branch to pull.
-                                short_branch_name = _default_branch(repo)
-                                pc_logging.debug("Refreshing the GIT branch: %s" % short_branch_name)
-                                with telemetry.start_as_current_span(
-                                    "*ProjectFactoryGit._clone_or_update_repo.{Remote.fetch}"
-                                ):
-                                    fetched = _fetch(repo, short_branch_name)
-                                    repo.reset(fetched, ResetMode.HARD)
+                                with _ambient_config_guard.honoring_ambient_config():
+                                    short_branch_name = _default_branch(repo)
+                                    pc_logging.debug("Refreshing the GIT branch: %s" % short_branch_name)
+                                    with telemetry.start_as_current_span(
+                                        "*ProjectFactoryGit._clone_or_update_repo.{Remote.fetch}"
+                                    ):
+                                        fetched = _fetch(repo, short_branch_name)
+                                        repo.reset(fetched, ResetMode.HARD)
                                 self.ctx.stats_git_ops += 1
                                 os.utime(guard_path, (now, now))
                         else:
@@ -687,11 +815,12 @@ class ProjectFactoryGit(pf.ProjectFactory, GitImportConfiguration):
                                 # works either way.
                                 before = repo.head.target
                                 # Need to check for updates
-                                with telemetry.start_as_current_span(
-                                    "*ProjectFactoryGit._clone_or_update_repo.{Remote.fetch}"
-                                ):
-                                    fetched = _fetch(repo, self.import_revision)
-                                    repo.reset(fetched, ResetMode.HARD)
+                                with _ambient_config_guard.honoring_ambient_config():
+                                    with telemetry.start_as_current_span(
+                                        "*ProjectFactoryGit._clone_or_update_repo.{Remote.fetch}"
+                                    ):
+                                        fetched = _fetch(repo, self.import_revision)
+                                        repo.reset(fetched, ResetMode.HARD)
 
                                 self.ctx.stats_git_ops += 1
                                 os.utime(guard_path, (now, now))
@@ -734,10 +863,11 @@ class ProjectFactoryGit(pf.ProjectFactory, GitImportConfiguration):
                     try:
                         pc_logging.info("Cloning the GIT repo: %s" % self.import_config_url)
                         clone_options = get_clone_options(self.import_revision)
-                        with telemetry.start_as_current_span(
-                            "*ProjectFactoryGit._clone_or_update_repo.{clone_repository}"
-                        ):
-                            repo = self._clone_repo(repo_url, cache_path, clone_options)
+                        with _ambient_config_guard.honoring_ambient_config():
+                            with telemetry.start_as_current_span(
+                                "*ProjectFactoryGit._clone_or_update_repo.{clone_repository}"
+                            ):
+                                repo = self._clone_repo(repo_url, cache_path, clone_options)
                         self.ctx.stats_git_ops += 1
                         if self.import_revision is not None:
                             after = self.import_revision
@@ -758,6 +888,17 @@ class ProjectFactoryGit(pf.ProjectFactory, GitImportConfiguration):
                             )
                             time.sleep(patience)
                         else:
+                            # An authentication failure here is most often a
+                            # 'url.*.insteadOf' rewrite in the ambient git config
+                            # sending this anonymous clone to a transport whose
+                            # credentials are not available. Try once more with
+                            # that config ignored, using the URL as written,
+                            # before giving up. Other definitive failures (a 404,
+                            # a missing ref) are reported as-is.
+                            if is_auth_failure(e) and self._clone_ignoring_ambient_config(
+                                repo_url, cache_path, clone_options, guard_path
+                            ):
+                                break
                             pc_logging.error(
                                 "Failed to clone repo %s after %d retries", self.import_config_url, attempt
                             )

--- a/partcad/tests/unit/test_git_ambient_config_fallback.py
+++ b/partcad/tests/unit/test_git_ambient_config_fallback.py
@@ -1,0 +1,116 @@
+#
+# PartCAD, 2025
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""When a clone fails, PartCAD retries it once with the ambient git config
+(the user's ~/.gitconfig and the system config) ignored, so a 'url.*.insteadOf'
+rewrite there cannot break an otherwise anonymous clone. These tests drive that
+fallback without touching the network by making the fake clone succeed only when
+the ambient config search path has been cleared."""
+
+import tempfile
+
+import pytest
+import pygit2
+from pygit2 import GitError
+from pygit2.enums import ConfigLevel
+from unittest.mock import MagicMock, mock_open, patch
+
+import partcad as pc
+from partcad.user_config import UserConfig
+
+repo_url = "https://github.com/partcad/partcad"
+test_config_import_git = {
+    "name": "//part_step",
+    "type": "git",
+    "url": repo_url,
+    "relPath": "examples/produce_part_step",
+}
+
+# What GitCallbacks raises when an insteadOf-rewritten URL needs credentials
+# that are not available. It is deliberately not a retryable error, so it drops
+# straight to the ambient-config fallback.
+auth_error = GitError("Authentication is required for 'ssh://git@github.com/partcad/partcad' and no credentials")
+
+
+@pytest.fixture
+def user_config():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config = UserConfig()
+        config.internal_state_dir = tmpdir
+        config.set("git.clone.retry.max", 2)
+        config.set("git.clone.retry.patience", 0.01)
+        yield config
+
+
+def _ambient_config_ignored() -> bool:
+    """Whether the fallback has cleared the config search path for this call."""
+    return pygit2.settings.search_path[ConfigLevel.GLOBAL] == ""
+
+
+def test_clone_falls_back_to_ignoring_ambient_config(user_config):
+    """A clone that fails while honoring the ambient config succeeds once it is
+    ignored, and the search path is restored afterwards."""
+
+    def side_effect(*args, **kwargs):
+        side_effect.counter += 1
+        if _ambient_config_ignored():
+            return MagicMock()
+        raise auth_error
+
+    side_effect.counter = 0
+    saved = pygit2.settings.search_path[ConfigLevel.GLOBAL]
+
+    with (
+        patch("partcad.project_factory_git._clone", side_effect=side_effect),
+        patch("builtins.open", mock_open(read_data="")),
+    ):
+        ctx = pc.Context(user_config=user_config)
+        factory = pc.ProjectFactoryGit(ctx, None, test_config_import_git)
+        assert factory is not None
+
+    # Honored the ambient config first (and failed), then ignored it (and won).
+    assert side_effect.counter >= 2
+    # The process-wide search path is left exactly as it was found.
+    assert pygit2.settings.search_path[ConfigLevel.GLOBAL] == saved
+
+
+def test_search_path_restored_when_fallback_also_fails(user_config):
+    """Even if ignoring the ambient config does not help, the search path is
+    restored and the failure is reported as a clean RuntimeError."""
+
+    def side_effect(*args, **kwargs):
+        raise auth_error
+
+    saved = pygit2.settings.search_path[ConfigLevel.GLOBAL]
+
+    with (
+        patch("partcad.project_factory_git._clone", side_effect=side_effect),
+        pytest.raises(RuntimeError),
+    ):
+        ctx = pc.Context(user_config=user_config)
+        pc.ProjectFactoryGit(ctx, None, test_config_import_git)
+
+    assert pygit2.settings.search_path[ConfigLevel.GLOBAL] == saved
+
+
+def test_successful_clone_never_touches_the_search_path(user_config):
+    """The happy path honors the ambient config and never clears the search
+    path, so a clone always sees the user's configuration when it works."""
+
+    seen = []
+
+    def side_effect(*args, **kwargs):
+        seen.append(_ambient_config_ignored())
+        return MagicMock()
+
+    with (
+        patch("partcad.project_factory_git._clone", side_effect=side_effect),
+        patch("builtins.open", mock_open(read_data="")),
+    ):
+        ctx = pc.Context(user_config=user_config)
+        pc.ProjectFactoryGit(ctx, None, test_config_import_git)
+
+    assert seen  # the clone ran
+    assert not any(seen)  # and always honored the ambient config

--- a/partcad/tests/unit/test_healthcheck_stale_git_locks.py
+++ b/partcad/tests/unit/test_healthcheck_stale_git_locks.py
@@ -1,0 +1,64 @@
+#
+# PartCAD, 2025
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""The StaleGitLocks healthcheck removes leftover git cache lock files that no
+process holds, and never touches a lock a process still holds."""
+
+import os
+
+import pytest
+from filelock import FileLock
+
+from partcad.user_config import user_config
+from partcad.healthcheck.stale_git_locks import StaleGitLocksCheck
+
+
+@pytest.fixture
+def git_cache(tmp_path, monkeypatch):
+    """Point the healthcheck at a temporary internal state dir with a git/ dir."""
+    git_dir = tmp_path / "git"
+    git_dir.mkdir()
+    monkeypatch.setattr(user_config, "internal_state_dir", str(tmp_path))
+    return git_dir
+
+
+def test_not_applicable_without_git_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr(user_config, "internal_state_dir", str(tmp_path))
+    assert StaleGitLocksCheck().is_applicable() is False
+
+
+def test_stale_lock_is_reported_and_removed(git_cache):
+    stale = git_cache / "deadbeef.lock"
+    stale.write_text("")
+
+    check = StaleGitLocksCheck()
+    assert check.is_applicable() is True
+
+    report = check.test()
+    assert any("deadbeef.lock" in finding for finding in report.findings)
+
+    assert check.fix() is True
+    assert not stale.exists()
+
+
+def test_held_lock_is_left_untouched(git_cache):
+    held_path = git_cache / "held.lock"
+    held = FileLock(str(held_path))
+    held.acquire()
+    try:
+        check = StaleGitLocksCheck()
+        report = check.test()
+        # A lock a process still holds is not reported as stale...
+        assert not any("held.lock" in finding for finding in report.findings)
+        # ...and a fix pass leaves it in place.
+        check.fix()
+        assert held_path.exists()
+    finally:
+        held.release()
+
+
+def test_no_locks_is_a_clean_pass(git_cache):
+    report = StaleGitLocksCheck().test()
+    assert report.findings == []


### PR DESCRIPTION
## Summary

libgit2 reads the user's `~/.gitconfig` and the system git config directly. A `url.*.insteadOf` rewrite there — commonly `https://github.com/` → `ssh://git@github.com/` to enforce SSH — hijacks PartCAD's **anonymous** clone of a **public** repository onto a transport whose credentials are not available in the current environment (a dev container with no forwarded SSH key, CI, …). The import then fails through no fault of the package.

This makes PartCAD's git handling resilient to that ambient configuration and safe for several `pc` processes to share the cache.

## What changed

- **Ambient-config fallback.** When a clone fails **to authenticate**, PartCAD retries it once with the ambient global/system git config ignored (clearing libgit2's config search path), so the URL is used as written and the public repo clones over anonymous HTTPS. Setups that legitimately rely on the ambient config keep working — it is ignored **only after** a clone has already failed to authenticate. Transient network errors (retried as before) and definitive answers (a 404, a missing ref) are left untouched, so a genuinely missing repository is still reported, not retried.
- **Cross-process cache safety.** Each cached repository is now guarded by a `filelock` file lock, so two `pc` processes never clone into the same directory at once — not just two threads. (`filelock` is already a dependency, used by the Python runtimes.)
- **`StaleGitLocks` healthcheck.** A new auto-discovered healthcheck finds leftover git cache lock files that no running process holds and removes them: `pc healthcheck --filters git` to report, `--fix` to clean up. A lock a live process still holds is never touched.

### Concurrency design

The libgit2 config search path is a single process-wide setting, so clearing it for one clone would strip the ambient config from every clone running beside it in the same process (imports run concurrently on a thread pool). An in-process readers–writer guard coordinates it: clones that honor the ambient config are **readers** and stay concurrent; the fallback that clears the search path is the **writer**, running only when no reader is in flight, and restores the search path afterwards. The search path is process-local memory, so this is purely intra-process; cross-process safety of the on-disk cache is the separate `filelock` concern.

## Testing

- New `test_git_ambient_config_fallback.py` (3 tests): the fallback drives an otherwise-failing clone to success once the config is ignored, restores the search path afterwards (even when the fallback also fails), and never touches the search path on the happy path.
- New `test_healthcheck_stale_git_locks.py` (4 tests): a stale lock is reported and removed; a held lock is left alone; a clean cache passes; the check is not applicable without a git cache dir.
- `pytest partcad/tests -n 4 -m "not slow"`: **360 passed, 18 skipped, 0 failed** — run with the SSH-enforcing `insteadOf` rewrite **active**, which the fallback now carries (it previously failed the git-clone tests in that environment).
- Verified end to end against `./examples`: a fresh `pc list packages -r` (which clones the public index) now succeeds under the SSH-enforcing config, logging the fallback; the healthcheck detects and removes stale lock files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
