### PR TITLE
perf(examples): speed up SDF examples and raise Examples CI timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -277,7 +277,9 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.set-matrix.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    # Raised 30->40: the SDF examples add marching-cubes render time that pushed
+    # this matrix past ~30m on the slower Windows runners.
+    timeout-minutes: 40
 
     steps:
       - uses: actions/checkout@v7
@@ -329,7 +331,9 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.set-matrix.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    # Raised 30->40: the SDF examples add marching-cubes render time that pushed
+    # this matrix past ~30m on the slower Windows runners.
+    timeout-minutes: 40
 
     steps:
       - uses: actions/checkout@v7

--- a/examples/feature_convert_part/partcad.yaml
+++ b/examples/feature_convert_part/partcad.yaml
@@ -108,6 +108,8 @@ parts:
         default: 1.0
       height:
         default: 1.0
+      samples:
+        default: 16384
 
 
 # ---------------------------- #

--- a/examples/produce_part_ai_sdf/partcad.yaml
+++ b/examples/produce_part_ai_sdf/partcad.yaml
@@ -15,12 +15,18 @@ parts:
     desc: A cube
     properties:
       length: 10
+    parameters:
+      samples:
+        default: 16384
   prism:
     type: ai-sdf
     provider: openai
     desc: A hexagonal prism
     properties:
       length: 10
+    parameters:
+      samples:
+        default: 16384
   tetrahedron:
     type: ai-sdf
     provider: openai
@@ -29,6 +35,9 @@ parts:
     desc: A tetrahedron
     properties:
       length: 10
+    parameters:
+      samples:
+        default: 16384
 
 render:
   readme:

--- a/examples/produce_part_sdf/partcad.yaml
+++ b/examples/produce_part_sdf/partcad.yaml
@@ -19,6 +19,8 @@ parts:
         default: 1.0
       gear_count:
         default: 16
+      samples:
+        default: 16384
   box:
     desc: This is a cube defined using SDF.
     type: sdf
@@ -29,6 +31,8 @@ parts:
         default: 5.0
       height:
         default: 5.0
+      samples:
+        default: 16384
   blobby:
     desc: This is a blobby shape defined using SDF.
     type: sdf
@@ -43,6 +47,8 @@ parts:
         default: 1.5
       blend_value:
         default: 1
+      samples:
+        default: 16384
 
 render:
   readme:


### PR DESCRIPTION
Follow-up to #393 (merged).

The SDF examples added in #393 render via marching cubes (default `samples=2^16`), which added enough time to push the already-near-limit `Examples` CI matrix past its 30-minute timeout on the slower Windows runners — the *passing* Windows cell was running ~28.5m of the 30m budget, so runner variance intermittently tipped it over (it cancelled `Examples (PartCAD) (windows-latest, 3.11)` in the #393 run; the test content itself had passed).

## Changes
- **Faster examples:** set `samples=2^14` on the SDF example parts (`produce_part_sdf`, `produce_part_ai_sdf`, `feature_convert_part`). Keeps the example meshes and svg/png renders valid while cutting marching-cubes time.
- **Timeout:** raise the `Examples (PartCAD)` and `Examples (All)` job timeouts 30 → 40 (both run the SDF examples), with a documenting comment matching the existing 20→30 note in this workflow.

## Validation
SDF/ai-sdf instantiation, the `box_sdf` convert matrix, and svg rendering all pass with the lighter sample count; the commit passes the pre-commit gate (pytest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
