### PR TITLE
fix(plugins): make external (plugin-backed) packages usable from sync consumers

### DIFF
--- a/partcad/src/partcad/project.py
+++ b/partcad/src/partcad/project.py
@@ -809,7 +809,7 @@ class Project(project_config.Configuration):
             # enumerable configs rather than the instantiated 'objects' dict -
             # a plugin-backed package enumerates lazily and may not have
             # instantiated the base yet.
-            if not base_object_name in object_configs:
+            if base_object_name not in object_configs:
                 pc_logging.error(
                     "Base object '%s' not found in '%s'",
                     base_object_name,

--- a/partcad/src/partcad/project.py
+++ b/partcad/src/partcad/project.py
@@ -803,8 +803,13 @@ class Project(project_config.Configuration):
                     pc_logging.error("Failed to instantiate a non-parametrized object %s" % object_name)
                 return objects[object_name]
 
-            # This object has params (part_name != result_name)
-            if not base_object_name in objects:
+            # This object has params (part_name != result_name). Only the base
+            # object's *config* is needed to derive the parametrized variant
+            # (see 'object_configs[base_object_name]' below), so check the
+            # enumerable configs rather than the instantiated 'objects' dict -
+            # a plugin-backed package enumerates lazily and may not have
+            # instantiated the base yet.
+            if not base_object_name in object_configs:
                 pc_logging.error(
                     "Base object '%s' not found in '%s'",
                     base_object_name,

--- a/partcad/src/partcad/project_external_repository.py
+++ b/partcad/src/partcad/project_external_repository.py
@@ -8,6 +8,7 @@
 #
 
 import asyncio
+import concurrent.futures
 import json
 import threading
 
@@ -68,6 +69,9 @@ class ProjectExternalRepository(ProjectPlugin):
         self._cache = cache
         self._request_cache: dict[str, object] = {}
         self._request_lock = threading.Lock()
+        # Objects are instantiated once, lazily, after enumeration (see
+        # 'ensure_enumerated_async'); this guards against doing it twice.
+        self._objects_instantiated = False
         super().__init__(ctx, name, path, config_obj=config_obj, inherited_config=inherited_config)
 
     def request(self, key: str, handler):
@@ -183,16 +187,29 @@ class ProjectExternalRepository(ProjectPlugin):
         """Synchronous fetch, for accessors reached outside an event loop.
 
         Returns the cached value if present (so this never blocks once the async
-        traversal has warmed the cache); otherwise it bridges to the async fetch.
-        Bridging is only safe outside a running loop, which holds for the CLI
-        entry points; inside the loop, enumeration is warmed via
-        'ensure_enumerated_async' so this path stays a cache hit.
+        traversal has warmed the cache). On a miss it bridges to the async
+        fetch. The bridge is normally 'asyncio.run', but a synchronous accessor
+        can also be reached from *within* a running loop (e.g. 'render_async'
+        calls the synchronous 'get_part', which reaches here through
+        'object_configs'). Nesting 'asyncio.run' in that case raises; instead the
+        coroutine is completed on a worker thread, so the accessor stays usable
+        from both contexts even when the cache was not pre-warmed.
         """
         scoped = self._scope(key)
         with self._request_lock:
             if scoped in self._request_cache:
                 return self._request_cache[scoped]
-        return asyncio.run(self.get_data_async(key))
+
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            # No loop is running: bridge directly.
+            return asyncio.run(self.get_data_async(key))
+
+        # A loop is already running in this thread: run the fetch to completion
+        # on a separate thread to avoid nesting event loops.
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            return pool.submit(lambda: asyncio.run(self.get_data_async(key))).result()
 
     async def ensure_enumerated_async(self):
         """Warm the metadata, object and dependency caches from the repository.
@@ -213,6 +230,36 @@ class ProjectExternalRepository(ProjectPlugin):
                 )
         # Warm 'deps' too, so the synchronous 'dependencies()' is a cache hit.
         await self.get_data_async("deps")
+
+        # The object configs are now known, so instantiate the objects into the
+        # eager 'parts'/'sketches'/'assemblies' dictionaries the synchronous
+        # consumers read, honoring the promise made where this is awaited (see
+        # Context._process_project) that downstream 'list'/render/export observe
+        # a populated package. 'ProjectPlugin' deferred this (its
+        # '_instantiate_objects' is a no-op) because nothing was known at
+        # construction. Geometry stays lazy - only the factories are created.
+        if not self._objects_instantiated:
+            self._objects_instantiated = True
+            self._instantiate_enumerated()
+
+    def _instantiate_enumerated(self):
+        """Instantiate the enumerated objects into the eager object dicts.
+
+        Each object is created independently and defensively: one that cannot be
+        built (e.g. an unsupported type, or a file-backed object whose file is
+        absent) is skipped with a warning instead of hiding every other object
+        from a 'list'. Geometry is not built here - only the factories.
+        """
+        for kind, getter in (
+            ("sketch", self.get_sketch),
+            ("part", self.get_part),
+            ("assembly", self.get_assembly),
+        ):
+            for name in self.object_names(kind):
+                try:
+                    getter(name)
+                except Exception as e:
+                    pc_logging.warning("%s: could not instantiate %s '%s': %s" % (self.name, kind, name, e))
 
     async def _materialize_meta_async(self):
         """Fill package-level metadata from the repository.

--- a/partcad/src/partcad/project_external_repository.py
+++ b/partcad/src/partcad/project_external_repository.py
@@ -8,13 +8,13 @@
 #
 
 import asyncio
-import concurrent.futures
 import json
 import threading
 
 from .cache_hash import CacheHash
 from .project import OBJECT_KINDS
 from .project_plugin import ProjectPlugin
+from .sync_threads import threadpool_manager
 from . import logging as pc_logging
 
 # Distinguishes "no cached value" from a cached value of None.
@@ -207,9 +207,10 @@ class ProjectExternalRepository(ProjectPlugin):
             return asyncio.run(self.get_data_async(key))
 
         # A loop is already running in this thread: run the fetch to completion
-        # on a separate thread to avoid nesting event loops.
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-            return pool.submit(lambda: asyncio.run(self.get_data_async(key))).result()
+        # on the shared, otel-context-preserving executor to avoid nesting event
+        # loops (a raw ThreadPoolExecutor would drop the tracing context).
+        future = threadpool_manager.unconstrained_executor.submit(lambda: asyncio.run(self.get_data_async(key)))
+        return future.result()
 
     async def ensure_enumerated_async(self):
         """Warm the metadata, object and dependency caches from the repository.


### PR DESCRIPTION
## Summary

Follows up on plugin-backed packages (#457). An `external` package enumerates its objects lazily and does **not** instantiate them or populate the eager `parts`/`sketches`/`assemblies` dictionaries at construction time. But the synchronous consumers still read those dictionaries, so a plugin-backed package appeared **empty** to `pc list` / `render` / `export`, and rendering a specific part raised from inside the render event loop. This lands three targeted fixes so plugin-backed packages behave like local ones through the existing interfaces.

## Changes

- **Populate the eager object dicts after enumeration.** `ensure_enumerated_async` (awaited during the import traversal, see `Context._process_project`) now instantiates the enumerated objects into `parts`/`sketches`/`assemblies`, honoring the promise made there that downstream consumers observe a populated package. Each object is instantiated defensively — one that can't be built (unsupported type, missing file) is skipped with a warning instead of hiding the rest of a `list`. **Geometry stays lazy**; only the factories are created.
- **Make the synchronous `get_data` bridge loop-safe.** A sync accessor can be reached from *within* a running loop (`render_async` → `get_part` → `object_configs`). On a cold cache that previously raised `asyncio.run() cannot be called from a running event loop`. It now completes the coroutine on a worker thread in that case, so the accessor works from both contexts.
- **Fix parametrized names for plugin-backed parts.** `get_object` resolved the base of a parametrized name (`part;k=v`) via the eagerly-instantiated `objects` dict; it now checks the enumerable `object_configs` (which is exactly what the following line reads the base config from), so `part;k=v` works for a plugin-backed package.

## Testing

Verified against `devel`:

- `test_project_external_repository.py`, `test_project_relocation.py`, `test_assembly.py`, `test_openscad_params.py` — all pass.
- End to end with a real plugin-backed package ([`partcad-bosl2`](https://github.com/partcad/partcad-bosl2)): `pc list parts -r` shows the full catalog, individual parts render, and `part;name=value` parameter overrides produce distinct geometry.

Scope is limited to `project.py` (one guard) and `project_external_repository.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)