### PR TITLE
ci: drop Anaconda 'defaults' channel to fix the macOS/3.12 pygit2 segfault

### DIFF
--- a/.github/actions/setup-all/action.yml
+++ b/.github/actions/setup-all/action.yml
@@ -90,7 +90,19 @@ runs:
       with:
         miniforge-version: 24.11.3-0
         use-mamba: true
-        channels: conda-forge,defaults
+        # conda-forge only. Mixing Anaconda's 'defaults' ('pkgs/main') into a
+        # conda-forge environment picks whichever channel happens to hold the
+        # newer build, and the two are not ABI-compatible. That is how the
+        # macOS/3.12 job started segfaulting: 'defaults' ships cffi 2.1.0 for
+        # py312 while conda-forge is still on 1.17.1, so the Anaconda build won
+        # and satisfied pygit2's 'cffi>=2.0', which stopped pip from installing
+        # the PyPI wheel that pygit2's own wheel is built against. Its
+        # _cffi_backend mis-passes variadic arguments on Apple arm64, so the
+        # first 'git_libgit2_opts(GIT_OPT_GET_SEARCH_PATH, level, git_buf *)'
+        # handed libgit2 a garbage pointer to write through. With conda-forge
+        # alone, cffi resolves below pygit2's floor and pip installs the PyPI
+        # wheel -- which is what the 3.10 and 3.11 jobs already do.
+        channels: conda-forge
         python-version: ${{ matrix.python-version }}
         activate-environment: test
         auto-activate-base: false

--- a/.github/workflows/build-standalone.yml
+++ b/.github/workflows/build-standalone.yml
@@ -219,7 +219,11 @@ jobs:
         with:
           miniforge-version: 24.11.3-0
           use-mamba: true
-          channels: conda-forge,defaults
+          # conda-forge only, for the same ABI reason as in setup-all -- see the
+          # comment there. The runtime sandbox PartCAD provisions below inherits
+          # this channel list, so leaving 'defaults' in would let Anaconda builds
+          # into it too.
+          channels: conda-forge
           # Only base is needed -- PartCAD creates its own sandbox env at
           # runtime. No named env, which is the part of setup-all that is flaky
           # enough to need continue-on-error.


### PR DESCRIPTION
## Summary

Fixes the `Pytest (macos-latest, 3.12)` segfault seen on #462, #463 and any other branch off current `devel`. It is a CI environment defect, not a bug in either of those PRs — both merely inherit it.

The job dies at the first read of libgit2's config search path:

```
partcad/tests/unit/test_git_ambient_config_fallback.py:63  pygit2.settings.search_path[ConfigLevel.GLOBAL]
  pygit2/options.py:346  C.git_libgit2_opts(GIT_OPT_GET_SEARCH_PATH, ffi.cast('int', level), buf)
→ Segmentation fault: 11   (exit 139)
```

## Root cause

`.github/actions/setup-all/action.yml` set `channels: conda-forge,defaults`. Mixing Anaconda's `defaults` (`pkgs/main`) into an otherwise conda-forge environment lets the resolver take whichever channel holds the newer build, and the two are not ABI-compatible.

Comparing all four Pytest jobs in run [30185201315](https://github.com/partcad/partcad/actions/runs/30185201315), the differentiator is **which `cffi` build ends up active**:

| Job | conda-resolved cffi | pip replaces it? | active `_cffi_backend` | Result |
|---|---|---|---|---|
| macOS 3.10 | 1.15.1 (conda-forge) | yes → PyPI wheel | PyPI | pass |
| macOS 3.11 | 1.15.1 (conda-forge) | yes → PyPI wheel | PyPI | pass |
| macOS 3.12 | **2.1.0 (`pkgs/main`)** | **no** — already ≥2.0 | **Anaconda** | **SEGV** |
| ubuntu 3.12 | **2.1.0 (`pkgs/main`)** | **no** | **Anaconda** | pass |

`defaults` ships cffi **2.1.0** for py312 while conda-forge is still on **1.17.1**, so the Anaconda build won and already satisfied pygit2's `cffi>=2.0` — pip then never installed the PyPI wheel that pygit2's own wheel is built against. On 3.10/3.11 conda lands 1.15.1, *below* pygit2's floor, so pip does replace it there. That is the whole reason only 3.12 was affected.

**Why it crashes.** pygit2 declares `int git_libgit2_opts(int option, ...)`. cffi refuses to generate a static wrapper for a variadic function (`cffi/recompiler.py:668` — *"cannot support vararg functions better than this... build it as a constant function pointer"*), so every call is dispatched at runtime through `_cffi_backend`'s libffi. Apple arm64 passes variadic arguments **on the stack** rather than in registers; the Anaconda backend gets that wrong there, so libgit2's `va_arg(ap, git_buf *)` in `GIT_OPT_GET_SEARCH_PATH` receives a garbage pointer and writes through it. Linux/x86-64 passes varargs in registers, which is why ubuntu/3.12 survives the *identical* cffi build — Apple arm64 is the necessary second ingredient.

**Why now.** Reading the search path is the first call PartCAD makes that hands libgit2 a pointer to *write through* as a vararg, and the only code doing so is the ambient-git-config fallback added in #458. The pre-existing `pygit2.settings.server_connect_timeout` writes (`project_factory_git.py:97-98`) take the same broken path but only pass a scalar, so they quietly set a wrong timeout instead of faulting — which is why nothing crashed before.

## Change

`channels: conda-forge` in both places that configure `setup-miniconda`. With conda-forge alone, py312 cffi resolves to 1.17.1 — below pygit2's floor — so pip installs the PyPI `cffi-2.1.0-cp312-cp312-macosx_11_0_arm64.whl`, reproducing exactly the configuration the 3.10 and 3.11 jobs already pass with.

Applied to `build-standalone.yml` too: the runtime sandbox PartCAD provisions there inherits the channel list, so leaving `defaults` in would let Anaconda builds into the standalone bundles as well.

Dropping `defaults` also removes an Anaconda ToS exposure for CI use.

## Validation

- `pre-commit run --config dev-tools/pre-commit-config.yaml` passes in the dev container, including the **Validate GitHub Actions** and **Validate GitHub Workflows** schema hooks.
- The real check is this PR's own `Pytest (macos-latest, 3.12)` job — it exercises the changed action and must now get past `test_git_ambient_config_fallback.py`.

## Follow-ups (not in this PR)

- `pyproject.toml:138` has `pygit2 = ">=1.15.0"` unbounded. That is how 1.19.3 arrived silently and why 3.10 and 3.11 run different majors in the same matrix. An upper bound would make such jumps visible.
- The #458 fallback mutates a **process-global** libgit2 setting, which is what requires the `_AmbientConfigGuard` reader/writer lock. Doing that clone in a subprocess with a scratch `HOME` would drop both the global mutation and this crash-prone pygit2 API. Note `GIT_CONFIG_GLOBAL` is *not* a viable shortcut — I verified against pygit2 1.19.3 that libgit2 ignores it (it is git-CLI-only) and resolves the global config from `$HOME` per process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
