### PR TITLE
fix(project): treat a null shape section as empty during enumeration

### DIFF
--- a/partcad/src/partcad/project.py
+++ b/partcad/src/partcad/project.py
@@ -1197,7 +1197,9 @@ class Project(project_config.Configuration):
 
     def _enumerate_shapes(self, sketches, interfaces, parts, assemblies):
         def get_keys(name):
-            return list(self.config_obj.get(name, {}).keys()) if name in self.config_obj else []
+            # A section that is present but empty (e.g. `sketches:` with no
+            # entries, as `pc init` writes it) parses as None; treat it as {}.
+            return list((self.config_obj.get(name) or {}).keys()) if name in self.config_obj else []
 
         sketches = sketches or get_keys("sketches")
         # interfaces = sketches or get_keys("interfaces")

--- a/partcad/tests/unit/data/enum_null_all.yaml
+++ b/partcad/tests/unit/data/enum_null_all.yaml
@@ -1,0 +1,5 @@
+# Every shape section is present but empty (null), exactly as `pc init` leaves
+# them in a fresh package. Enumeration must treat a null section as empty.
+sketches:
+parts:
+assemblies:

--- a/partcad/tests/unit/data/enum_null_mixed/cube.py
+++ b/partcad/tests/unit/data/enum_null_mixed/cube.py
@@ -1,0 +1,4 @@
+import cadquery as cq
+
+result = cq.Workplane("XY").box(1, 1, 1)
+show_object(result)

--- a/partcad/tests/unit/data/enum_null_mixed/partcad.yaml
+++ b/partcad/tests/unit/data/enum_null_mixed/partcad.yaml
@@ -1,0 +1,8 @@
+# A null `sketches:`/`assemblies:` section next to a populated `parts:` section
+# — the state produced by `pc init` followed by `pc add part`.
+sketches:
+parts:
+  cube:
+    type: cadquery
+    path: cube.py
+assemblies:

--- a/partcad/tests/unit/test_enumerate_shapes.py
+++ b/partcad/tests/unit/test_enumerate_shapes.py
@@ -1,0 +1,28 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+
+import partcad as pc
+
+
+def test_enumerate_shapes_all_null_sections():
+    """`sketches:`/`parts:`/`assemblies:` present but null (as `pc init` writes
+    them) must not crash shape enumeration.
+
+    Regression: get_keys() used ``config_obj.get(name, {})``, which returns
+    ``None`` for a key that exists with a null value, and then ``.keys()`` raised
+    ``AttributeError: 'NoneType' object has no attribute 'keys'``.
+    """
+    ctx = pc.Context("partcad/tests/unit/data/enum_null_all.yaml")
+    prj = ctx.get_project(pc.ROOT)
+    assert prj._enumerate_shapes(None, None, None, None) == []
+
+
+def test_enumerate_shapes_null_section_with_parts():
+    """A null section next to a populated one still enumerates the populated one."""
+    ctx = pc.Context("partcad/tests/unit/data/enum_null_mixed/partcad.yaml")
+    prj = ctx.get_project(pc.ROOT)
+    shapes = prj._enumerate_shapes(None, None, None, None)
+    assert len(shapes) == 1


### PR DESCRIPTION
## Problem

`pc init` writes the `sketches:`, `parts:`, and `assemblies:` sections of a new `partcad.yaml` as present-but-empty (null) keys. `Project._enumerate_shapes` reads them via `config_obj.get(name, {})`, which returns `None` when the key exists with a null value. The subsequent `.keys()` then raises:

```
AttributeError: 'NoneType' object has no attribute 'keys'
```

so `pc render` (and any shape enumeration) crashes on a freshly-initialized package — e.g. right after `pc init` + `pc add part`, when `sketches:`/`assemblies:` are still null.

## Fix

Guard the lookup with `or {}` so a null section is treated as `{}` — a one-line change in `get_keys`.

## Tests

`partcad/tests/unit/test_enumerate_shapes.py`:

- `test_enumerate_shapes_all_null_sections` — all three sections present and null → no crash, returns `[]`.
- `test_enumerate_shapes_null_section_with_parts` — null `sketches:`/`assemblies:` next to a populated `parts:` → the part is still enumerated.

Both fail without the fix (the `AttributeError`) and pass with it; the full unit suite passes via the pre-commit `pytest` hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
