### PR TITLE
fix(test): include manufacturable in the test-result cache key

### DIFF
--- a/partcad/src/partcad/test/test.py
+++ b/partcad/src/partcad/test/test.py
@@ -40,7 +40,11 @@ class Test(ABC):
     async def test_cached(self, tests_to_run: list["Test"], ctx, shape, test_ctx: dict = {}) -> bool:
         is_cacheable = shape.get_cacheable()
         if is_cacheable:
-            cache_key = f"test.{self.name}"
+            # The manufacturability tests depend on `manufacturable`, which is
+            # not part of shape.hash; fold it into the cache key so that flipping
+            # the flag invalidates any previously cached result.
+            manufacturable = int(bool(getattr(shape, "is_manufacturable", True)))
+            cache_key = f"test.{self.name}.manufacturable={manufacturable}"
             cached_results = await ctx.cache_tests.read_data_async(shape.hash, [cache_key])
             cached_bytes = cached_results.get(cache_key, [])
             if cached_bytes and len(cached_bytes) != 0:

--- a/partcad/tests/unit/test_test_cache.py
+++ b/partcad/tests/unit/test_test_cache.py
@@ -1,0 +1,66 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+
+import asyncio
+
+from partcad.test.test import Test
+
+
+class _FakeCache:
+    def __init__(self):
+        self.reads = []
+
+    async def read_data_async(self, shape_hash, keys):
+        self.reads.append((shape_hash, tuple(keys)))
+        return {k: [] for k in keys}  # always a cache miss
+
+    async def write_data_async(self, shape_hash, data):
+        pass
+
+
+class _FakeCtx:
+    def __init__(self):
+        self.cache_tests = _FakeCache()
+
+
+class _FakeShape:
+    def __init__(self, manufacturable):
+        self.hash = "identical-geometry-hash"
+        self.is_manufacturable = manufacturable
+        self.name = "part"
+        self.project_name = "pkg"
+
+    def get_cacheable(self):
+        return True
+
+
+class _PassTest(Test):
+    async def test(self, tests_to_run, ctx, shape, test_ctx={}):
+        return self.TEST_PASSED
+
+
+def _cache_read_identity(manufacturable):
+    Test.MAX_CONCURRENT_TESTS = 8
+    Test.semaphore = None  # let each asyncio.run() build its own in its own loop
+    ctx = _FakeCtx()
+    asyncio.run(_PassTest("cam").test_cached([], ctx, _FakeShape(manufacturable)))
+    # The (shape_hash, (cache_key,)) the test looked up in the cache.
+    return ctx.cache_tests.reads[0]
+
+
+def test_test_cache_key_depends_on_manufacturable():
+    """Two shapes with identical geometry but different `manufacturable` must not
+    share a test-result cache entry.
+
+    Regression: the cache was keyed on shape.hash alone, so a cam failure cached
+    while manufacturable=True was still returned after flipping to False.
+    """
+    ident_true = _cache_read_identity(True)
+    ident_false = _cache_read_identity(False)
+    # Same geometry hash on both ...
+    assert ident_true[0] == ident_false[0]
+    # ... but different cache identity, because the key encodes manufacturable.
+    assert ident_true != ident_false


### PR DESCRIPTION
## Problem

The test-result cache (`Test.test_cached`) is keyed on `shape.hash`, which does not include the `manufacturable` flag. The manufacturability tests (`cam`, `cam-additive`, …) short-circuit to *passed* when a shape is `manufacturable: false`, so their result depends on that flag — but the cache does not.

Consequence: a `cam` failure cached while `manufacturable: true` (e.g. a part with no supplier) is served from the cache after the part is flipped to `manufacturable: false`, so `pc test` keeps reporting the stale failure even though it should now pass.

## Fix

Fold `manufacturable` into the test cache key so flipping the flag invalidates any previously cached result:

```
test.{name}  ->  test.{name}.manufacturable={0|1}
```

Both the read and the write use `cache_key`, so the one change covers both.

## Test

`partcad/tests/unit/test_test_cache.py` drives `Test.test_cached` with a fake cache and asserts that two shapes with an identical geometry hash but different `manufacturable` look up **different** cache identities. Fails without the fix (identical keys), passes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
