### PR TITLE
feat(ai-agents): PartCAD skills plugin for AI coding agents

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "partcad",
+  "description": "PartCAD skills for AI coding agents",
+  "owner": {
+    "name": "Roman Kuzmenko",
+    "email": "rkuz@partcad.org"
+  },
+  "plugins": [
+    {
+      "name": "pc",
+      "description": "Mechanical and robotics engineering with PartCAD",
+      "source": "./ai-agents/claude"
+    }
+  ]
+}

--- a/.claude/skills/pc
+++ b/.claude/skills/pc
@@ -1,0 +1,1 @@
+../../ai-agents/claude

--- a/.github/workflows/ai-agents-release.yml
+++ b/.github/workflows/ai-agents-release.yml
@@ -1,0 +1,127 @@
+name: AI Agent Skills — Release
+
+# Publishes the symlink-free (Windows-safe) `pc` plugin when a release tag is
+# pushed. Create and push the tag from a clean tree with:
+#
+#     claude plugin tag ai-agents/claude --push
+#
+# which validates that plugin.json and the marketplace entry agree, then creates
+# `pc--v<version>` and pushes it — firing this workflow.
+#
+# CREDENTIALS: no Anthropic credentials and no user-managed secrets. `claude
+# plugin validate` runs offline; publishing uses only the automatic GITHUB_TOKEN
+# that GitHub Actions injects (no PAT, no stored secret).
+
+on:
+  push:
+    tags:
+      - "pc--v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to (re)publish, e.g. pc--v0.1.0"
+        required: true
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ai-agents-release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      DISABLE_AUTOUPDATER: "1"
+      DISABLE_TELEMETRY: "1"
+      DISABLE_ERROR_REPORTING: "1"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install Claude Code CLI (no login required)
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Resolve tag and verify version agrees with plugin.json
+        id: v
+        run: |
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          case "$TAG" in
+            pc--v*) ;;
+            *) echo "::error::Tag '$TAG' does not match pc--v*"; exit 1 ;;
+          esac
+          TAG_VER="${TAG#pc--v}"
+          MANIFEST_VER="$(node -p "require('./ai-agents/claude/.claude-plugin/plugin.json').version")"
+          if [ "$TAG_VER" != "$MANIFEST_VER" ]; then
+            echo "::error::Tag version ($TAG_VER) != plugin.json version ($MANIFEST_VER)"
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$TAG_VER" >> "$GITHUB_OUTPUT"
+
+      - name: Validate catalog and plugin
+        run: |
+          claude plugin validate .
+          claude plugin validate ai-agents/claude
+
+      - name: Materialize symlink-free artifact
+        run: ai-agents/scripts/materialize.sh
+
+      - name: Assert the artifact is symlink-free
+        run: |
+          if find ai-agents/.build -type l | grep -q .; then
+            echo "::error::Materialized artifact still contains symlinks"
+            find ai-agents/.build -type l
+            exit 1
+          fi
+          test -f ai-agents/.build/marketplace/pc/skills/init/SKILL.md
+
+      - name: Publish symlink-free marketplace to the plugin-dist branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ART="$PWD/ai-agents/.build/marketplace"
+          TAG="${{ steps.v.outputs.tag }}"
+          tmp="$(mktemp -d)"
+          mkdir -p "$tmp/.claude-plugin"
+          cp "$ART/.claude-plugin/marketplace.json" "$tmp/.claude-plugin/"
+          cp -R "$ART/pc" "$tmp/"
+          cd "$tmp"
+          git init -q
+          git checkout -q -b plugin-dist
+          git add -A
+          git -c user.name="github-actions[bot]" \
+              -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+              commit -qm "Publish pc plugin $TAG"
+          git push -f \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            plugin-dist
+
+      - name: Create GitHub Release with the plugin archive
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${{ steps.v.outputs.tag }}"
+          VER="${{ steps.v.outputs.version }}"
+          REPO="$GITHUB_REPOSITORY"
+          cat > "$RUNNER_TEMP/notes.md" <<'EOF'
+          Symlink-free PartCAD Claude plugin `pc` v__VER__.
+
+          **Install**
+          - Marketplace branch (recommended, always latest):
+            - `/plugin marketplace add __REPO__@plugin-dist`
+            - `/plugin install pc@partcad`
+          - Direct archive (immutable, Windows-safe):
+            - `claude --plugin-url https://github.com/__REPO__/releases/download/__TAG__/pc.zip`
+          EOF
+          sed -i "s|__VER__|${VER}|g; s|__REPO__|${REPO}|g; s|__TAG__|${TAG}|g" "$RUNNER_TEMP/notes.md"
+          gh release create "$TAG" ai-agents/.build/marketplace/pc.zip \
+            --repo "$REPO" --title "pc v${VER}" --notes-file "$RUNNER_TEMP/notes.md" \
+          || { gh release edit "$TAG" --repo "$REPO" --notes-file "$RUNNER_TEMP/notes.md"; \
+               gh release upload "$TAG" ai-agents/.build/marketplace/pc.zip --repo "$REPO" --clobber; }

--- a/.github/workflows/ai-agents.yml
+++ b/.github/workflows/ai-agents.yml
@@ -1,0 +1,66 @@
+name: AI Agent Skills
+
+# Validates the shared skills library and the Claude plugin, and proves the
+# publish-time materialization produces a symlink-free artifact.
+#
+# NO CREDENTIALS: `claude plugin validate` and the materialization script run
+# fully offline. This workflow must never reference ANTHROPIC_API_KEY, a login,
+# or any repository secret.
+
+on:
+  push:
+    paths:
+      - "ai-agents/**"
+      - ".claude-plugin/**"
+      - ".github/workflows/ai-agents.yml"
+  pull_request:
+    paths:
+      - "ai-agents/**"
+      - ".claude-plugin/**"
+      - ".github/workflows/ai-agents.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ai-agents-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    env:
+      DISABLE_AUTOUPDATER: "1"
+      DISABLE_TELEMETRY: "1"
+      DISABLE_ERROR_REPORTING: "1"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install Claude Code CLI (no login required)
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Show version
+        run: claude --version
+
+      - name: Validate marketplace catalog
+        run: claude plugin validate .
+
+      - name: Validate Claude plugin manifest
+        run: claude plugin validate ai-agents/claude
+
+      - name: Materialize symlink-free artifact and validate it
+        run: ai-agents/scripts/materialize.sh
+
+      - name: Assert the shipped artifact contains no symlinks
+        run: |
+          if find ai-agents/.build -type l | grep -q .; then
+            echo "::error::Materialized artifact still contains symlinks"
+            find ai-agents/.build -type l
+            exit 1
+          fi
+          test -f ai-agents/.build/marketplace/pc/skills/init/SKILL.md
+          echo "OK: materialized artifact is self-contained and symlink-free"

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ pc-test-results/
 pytest-results/
 test-results/
 *.code-workspace
+# Materialized (symlink-free) plugin artifact produced by ai-agents/scripts/materialize.sh
+/ai-agents/.build

--- a/ai-agents/README.md
+++ b/ai-agents/README.md
@@ -1,0 +1,129 @@
+# AI agent skills
+
+Skills for AI coding agents that work on PartCAD projects. The skills themselves
+are vendor-neutral [Agent Skills](https://code.claude.com/docs/en/skills)
+(`SKILL.md` folders) so any `SKILL.md`-aware agent can consume them; the Claude
+plugin is a thin wrapper that ships the same files to the Claude marketplace.
+
+## Layout
+
+```
+ai-agents/
+├── common/
+│   └── skills/                     # source of truth: one SKILL.md folder per skill
+│       └── init/SKILL.md           #   → usable by any agent that reads SKILL.md
+├── claude/                         # the Claude plugin (name: pc)
+│   ├── .claude-plugin/plugin.json
+│   └── skills -> ../common/skills  # symlink: no duplication
+└── scripts/
+    └── materialize.sh              # publish-time: deref the symlink into real files
+```
+
+Two more files outside this directory tie it together:
+
+- `../.claude-plugin/marketplace.json` — top-level catalog (for discoverability),
+  lists `pc` with `source: ./ai-agents/claude`.
+- `../.claude/skills/pc -> ../../ai-agents/claude` — makes Claude auto-discover
+  the plugin as `pc@skills-dir` when this repo is opened as the workspace, so
+  `/pc:init` is available with no install step.
+
+The plugin folder is named `claude`, but the command namespace comes from
+`plugin.json`'s `name` field (`pc`), so skills invoke as `/pc:<skill>`.
+
+## Skills
+
+- **`/pc:init`** — initializes a PartCAD package by delegating to the installed
+  CLI (`pc init` / `partcad init`). It resolves the command from `PATH` or the
+  active Python environment (`python -m partcad_cli.click.command`); if PartCAD
+  is missing it points the user at `/pc:install` instead of hand-writing files.
+- **`/pc:install <mode>`** — makes `pc`/`partcad` available. `executable`
+  installs the standalone PyInstaller build from the latest GitHub release via
+  the official `install.sh`; `python-module` installs the `partcad-cli` module
+  into the active Python environment (run as `python -m partcad_cli.click.command`).
+  Until a standalone release is published, `executable` reports that no published
+  installer is available and stops.
+- **`/pc:gen <description>`** — decides whether the request is a part or an
+  assembly and follows the matching flow below.
+- **`/pc:gen-part <description>`** — generates a single part: the agent picks a
+  representation (build123d / cadquery / openscad / sdf), authors the CAD script
+  itself, and validates it by rendering with `pc render`. Supersedes the legacy
+  `pc add part --ai` pipeline (the agent is the model; no provider/API key).
+- **`/pc:gen-assembly <description>`** — generates an assembly: reuses or
+  generates the component parts, authors the `.assy` (explicit placement or
+  interface mates), and validates by rendering. New capability — PartCAD had no
+  AI assembly path.
+
+## Local use (Claude)
+
+Open the repo root as the workspace and accept the trust prompt. Claude loads
+`pc@skills-dir`; run `/pc:init`. Notes:
+
+- Launch Claude from the **repo root** — project-scope skills-dir plugins do not
+  walk up from a subdirectory.
+- After editing a `SKILL.md`, changes are live; structural changes need
+  `/reload-plugins`.
+
+## Shipping to the Claude marketplace
+
+Installs on macOS/Linux dereference the `skills` symlink automatically, but
+**Windows git checkouts may not preserve symlinks**, which would ship an empty
+plugin. The release automation publishes a materialized (symlink-free) artifact,
+so what users install is safe everywhere.
+
+### Cut a release
+
+From a clean working tree, bump `version` in
+`ai-agents/claude/.claude-plugin/plugin.json`, commit, then:
+
+```bash
+claude plugin tag ai-agents/claude --push   # creates & pushes pc--v<version>
+```
+
+`claude plugin tag` validates that the manifest and the marketplace entry agree,
+then pushes a `pc--v<version>` tag. That fires
+`.github/workflows/ai-agents-release.yml`, which re-validates, runs
+`materialize.sh`, and publishes two ways:
+
+- **`plugin-dist` branch** — the symlink-free marketplace at its root (rolling
+  "latest"):
+  ```
+  /plugin marketplace add <owner>/<repo>@plugin-dist
+  /plugin install pc@partcad
+  ```
+- **GitHub Release** — `pc.zip` attached to the `pc--v<version>` release
+  (immutable, pin-able):
+  ```
+  claude --plugin-url https://github.com/<owner>/<repo>/releases/download/pc--v<version>/pc.zip
+  ```
+
+The release step needs no Anthropic credentials — it uses only the automatic
+`GITHUB_TOKEN` (no PAT, no stored secret).
+
+### Build the artifact locally
+
+```bash
+ai-agents/scripts/materialize.sh          # writes ai-agents/.build/marketplace
+```
+
+Produces a self-contained `pc/` plugin (real `skills/` files), a `marketplace.json`
+pointing at it, and `pc.zip`.
+
+Note: because the `skills` symlink escapes the plugin directory into `common/`, a
+lightweight `git-subdir` marketplace source will **not** work (the sparse clone
+misses `common/`); use the materialized artifact or a full-repo `github` source.
+
+## CI
+
+`.github/workflows/ai-agents.yml` validates the catalog and plugin with
+`claude plugin validate`, runs the materialization, and asserts the artifact is
+symlink-free. It uses **no credentials** — validation is fully offline.
+
+## Windows contributors
+
+If local discovery or a build produces a `skills` file containing the text
+`../common/skills` instead of a directory, git did not materialize the symlink.
+Enable symlinks and re-checkout:
+
+```bash
+git config core.symlinks true
+```

--- a/ai-agents/claude/.claude-plugin/plugin.json
+++ b/ai-agents/claude/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "pc",
+  "version": "0.1.0",
+  "description": "Mechanical and robotics engineering with PartCAD",
+  "author": {
+    "name": "Roman Kuzmenko",
+    "email": "rkuz@partcad.org"
+  }
+}

--- a/ai-agents/claude/skills
+++ b/ai-agents/claude/skills
@@ -1,0 +1,1 @@
+../common/skills

--- a/ai-agents/common/skills/gen-assembly/SKILL.md
+++ b/ai-agents/common/skills/gen-assembly/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: gen-assembly
+description: Generate a PartCAD assembly (an ASSY that composes parts with placement and/or mates) from a description, generating or reusing the component parts and validating the result with the PartCAD CLI. Use for /pc:gen-assembly or when the user asks to generate or create an assembly, mechanism, or multi-part product.
+---
+
+# pc:gen-assembly
+
+Generate a PartCAD **assembly**: an `.assy` file that composes parts (and
+sub-assemblies) into one product. The text after the command (`$ARGUMENTS`) is
+the assembly description. *You* author both the ASSY and its component parts and
+prove the whole thing **passes `pc test`**. There is no legacy `ai` assembly
+pipeline — this capability is new.
+
+## 1. Decompose
+
+`$ARGUMENTS` is the description. Break it into components and the
+spatial/mechanical relationships between them: which parts, how many of each, and
+how they attach to or move relative to one another. Clarify only load-bearing
+ambiguities.
+
+## 2. Inventory or generate the parts
+
+```sh
+pc list parts          # what already exists to reuse
+```
+
+Reuse existing parts; generate any missing component with the `/pc:gen-part`
+flow. Each part must pass `pc test` on its own before you compose it.
+
+## 3. Author the ASSY
+
+Scaffold (this creates the empty file and the `assemblies:` entry), then write
+`<name>.assy`:
+
+```sh
+pc add assembly assy <name>.assy
+```
+
+An ASSY file is a tree of nodes under `links:` (reference: PartCAD "Assembly YAML"
+docs, `docs/source/assy.rst`).
+
+**Container — the top level, and any grouping node:**
+
+```yaml
+name: <optional>
+description: <the description>
+location: <optional [[x,y,z], [ax,ay,az], angle_deg]>
+links:
+  - <node>
+  - <node>
+```
+
+**Part node** — places a part; use **exactly one** placement method:
+
+```yaml
+# explicit placement (translation, then rotation of angle_deg about the axis):
+- part: <part-in-this-package  or  //package:part>
+  name: <optional instance name>
+  location: [[x, y, z], [ax, ay, az], angle_deg]
+```
+
+```yaml
+# OR connect by ports (no interface mating):
+- part: <...>
+  connectPorts:
+    with: <this part's port, if it has more than one>
+    name: <target instance already in the assembly>
+    to: <target port, if the target has more than one>
+```
+
+```yaml
+# OR connect by interfaces (universal mating):
+- part: <...>
+  connect:
+    with: <this part's interface, if more than one>
+    name: <target instance already in the assembly>
+    to: <target interface, if more than one compatible>
+    # optional disambiguation: withInstance / withPort / toInstance / toPort
+```
+
+`location`, `connectPorts`, and `connect` are **mutually exclusive** — pick one
+per node. `with` names the interface/port on the part being added; `to` names it
+on the part already in the assembly.
+
+**Sub-assembly node** — identical to a part node but with `assembly:` instead of
+`part:`, and it may carry its own nested `links:`.
+
+Prefer `connect`/`connectPorts` when the parts define interfaces/ports; otherwise
+use explicit `location`. Work in millimeters and degrees.
+
+Then mark the assembly **not manufacturable** in `partcad.yaml` (it is generated,
+not a catalog item) so `pc test` passes:
+
+```yaml
+assemblies:
+  <name>:
+    type: assy
+    path: <name>.assy
+    manufacturable: false
+```
+
+## 4. Validate, render, iterate
+
+```sh
+pc test -a <name>                               # build gate: geometry instantiates
+mkdir -p /tmp/pc-render                         # the -O directory must already exist
+pc render -a -t png -O /tmp/pc-render <name>    # writes /tmp/pc-render/<name>.png
+```
+
+View `/tmp/pc-render/<name>.png`: check that components are positioned and
+oriented correctly and that nothing interpenetrates unintentionally, then adjust
+placements/mates. Iterate until it matches. `pc inspect -a <name>` gives an
+interactive view.
+
+## 5. Finalize
+
+Summarize the structure — parts, sub-assemblies, key placements — and how to view
+it (`pc inspect -a <name>`).

--- a/ai-agents/common/skills/gen-part/SKILL.md
+++ b/ai-agents/common/skills/gen-part/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: gen-part
+description: Generate a PartCAD part from a natural-language description (and optional reference images/requirements) by authoring a CAD script and validating it with the PartCAD CLI. Use for /pc:gen-part or when the user asks to generate, create, or model a single mechanical part.
+---
+
+# pc:gen-part
+
+Generate one PartCAD **part**. The text after the command (`$ARGUMENTS`) is the
+part description — what to build. *You* author the CAD script yourself and prove
+it works with the PartCAD CLI; do not use any built-in `ai-*` part type or
+generation pipeline. Hard requirement: the finished part **passes `pc test`** (its
+geometry instantiates cleanly).
+
+Steps 4–7 are the reference flow — the same shape the legacy `pc add part --ai`
+pipeline used (plan geometry → write script → validate → compare → refine). Treat
+it as a strong default, not a script: skip, reorder, or replace steps as the part
+warrants, but always finish by validating.
+
+## 1. Understand the request
+
+- `$ARGUMENTS` is the description. Read it and any `requirements`, and view
+  reference images directly. Ask the user to clarify only genuinely load-bearing
+  ambiguities; otherwise proceed and state your assumptions.
+- Work in millimeters and degrees unless told otherwise.
+
+## 2. Make sure PartCAD is available
+
+Resolve a command as `/pc:init` does (`pc`, then `partcad`, then
+`python -m partcad_cli.click.command`). If none is found, stop and run
+`/pc:install executable` first.
+
+## 3. Choose a representation
+
+Pick the script kind that best fits the part — you decide:
+
+| Kind | Good for |
+| --- | --- |
+| `build123d` | general parametric solids (recommended default) |
+| `cadquery` | fluent / CSG-style modeling |
+| `scad` (OpenSCAD) | simple constructive geometry, no Python |
+| `sdf` | organic / implicit shapes |
+
+## 4. (Optional) Plan the geometry
+
+For anything non-trivial, sketch the constructive-solid-geometry plan first —
+coordinate system, primitives with dimensions/positions/orientations, then
+unions/differences/intersections and fillets/chamfers. This mirrors the legacy
+"CSG" step and usually cuts iterations. Skip it for simple parts.
+
+## 5. Author, register, and mark it
+
+Write the script file **first** from `$ARGUMENTS` (plain type — never `ai-*`),
+then register it — `pc add part` requires the file to already exist:
+
+```sh
+pc add part --desc "<the description>" <kind> <name>.<ext>   # e.g. build123d bracket.py
+```
+
+Language conventions for the script:
+
+- **build123d / cadquery / sdf (Python):** import everything you use (including
+  `math` and the library itself); call `show_object(<result>)` to expose the
+  part; do not export anything. For cadquery, avoid `tetrahedron` / `hexahedron`.
+- **OpenSCAD:** a complete script defining all functions and constants; no
+  external modules; no export.
+
+Then mark the part **not manufacturable** in `partcad.yaml` — a generated part is
+not a catalog/supplier item, and this is what lets `pc test` pass:
+
+```yaml
+parts:
+  <name>:
+    type: <kind>
+    path: <name>.<ext>
+    desc: <the description>
+    manufacturable: false
+```
+
+If you started the project with `pc init`, also delete the empty `sketches:` and
+`assemblies:` sections it leaves — a null section crashes `pc render` on older
+PartCAD (fixed in partcad/partcad#470).
+
+## 6. Validate
+
+`pc test` is the build gate: with `manufacturable: false`, its CAD check passes
+only if the geometry instantiates cleanly, and the manufacturability checks are
+skipped.
+
+```sh
+pc test <name>
+```
+
+## 7. Render, compare, and iterate
+
+Produce an image and compare it against the description and any reference images
+— overall shape and every stated dimension:
+
+```sh
+mkdir -p /tmp/pc-render                       # the -O directory must already exist
+pc render -t png -O /tmp/pc-render <name>     # writes /tmp/pc-render/<name>.png
+```
+
+Fix any error or mismatch, then re-test and re-render. Iterate until it is right —
+no fixed retry count.
+
+## 8. Finalize
+
+Summarize what you built — key dimensions and assumptions — and how to view it:
+`pc inspect <name>`.

--- a/ai-agents/common/skills/gen/SKILL.md
+++ b/ai-agents/common/skills/gen/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: gen
+description: Generate PartCAD geometry from a description, automatically deciding whether the request is a single part or a multi-part assembly and following the matching flow. Use for /pc:gen or when the user asks to generate, create, or model something in PartCAD without saying whether it is a part or an assembly.
+---
+
+# pc:gen
+
+Entry point for PartCAD generation when the user has not said whether they want a
+single **part** or an **assembly**. The text after the command (`$ARGUMENTS`) is
+the description of what to build. Decide which it is, tell the user your choice,
+then follow that flow — passing the same description through.
+
+## Decide: part or assembly?
+
+- **Part** → `/pc:gen-part`. One continuous piece of geometry — a bracket, a
+  gear, a housing, a knob. Modeled as a single script, even when intricate.
+- **Assembly** → `/pc:gen-assembly`. Several distinct components that fit or move
+  relative to each other — a gearbox, a robot arm, a body with a lid, anything
+  joined by fasteners.
+
+Heuristics:
+
+- One noun, "a"/"single", one manufacturing process, one printed/machined piece
+  → **part**.
+- Plurals, "with", "attached to", "... and a ...", moving joints, fasteners, or
+  named sub-components → **assembly**.
+
+If it is genuinely ambiguous, ask one short question. Otherwise proceed with your
+best judgment and state which you picked — the user can redirect.
+
+## Then
+
+- Part → follow **`/pc:gen-part`**.
+- Assembly → follow **`/pc:gen-assembly`** (which itself uses `/pc:gen-part` for
+  any missing components).

--- a/ai-agents/common/skills/init/SKILL.md
+++ b/ai-agents/common/skills/init/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: init
+description: Initialize a PartCAD package in the current directory by running the installed PartCAD CLI (`pc init` / `partcad init`). Use when the user runs /pc:init or asks to initialize or create a PartCAD package or project.
+---
+
+# pc:init
+
+Initialize a PartCAD package in the current directory by delegating to the
+installed PartCAD command-line tool. Do **not** hand-write `partcad.yaml`
+yourself — run the real CLI so the result always matches the installed version.
+
+## 1. Locate the PartCAD command
+
+Find a usable invocation, most-preferred first, and remember it as `PARTCAD`.
+This covers a `pc`/`partcad` on `PATH` (a wheel install or the standalone
+bundle), and a `partcad-cli` that is importable in the current Python
+environment but whose console scripts are not on `PATH`:
+
+```sh
+if   command -v pc      >/dev/null 2>&1;         then PARTCAD="pc"
+elif command -v partcad >/dev/null 2>&1;         then PARTCAD="partcad"
+elif python  -c "import partcad_cli" >/dev/null 2>&1; then PARTCAD="python -m partcad_cli.click.command"
+elif python3 -c "import partcad_cli" >/dev/null 2>&1; then PARTCAD="python3 -m partcad_cli.click.command"
+else PARTCAD=""; fi
+echo "PARTCAD=${PARTCAD:-<none>}"
+```
+
+## 2. If nothing is installed
+
+If `PARTCAD` is empty, PartCAD is not available. Stop and tell the user to
+install it first — do not fabricate a `partcad.yaml`:
+
+> PartCAD is not installed. Run `/pc:install executable` for the standalone
+> build, or `/pc:install python-module` to install it into the current Python
+> environment, then re-run `/pc:init`.
+
+## 3. Run init
+
+Otherwise run PartCAD's own `init`, forwarding anything the user typed after the
+command (available as `$ARGUMENTS`):
+
+```sh
+$PARTCAD init $ARGUMENTS
+```
+
+If the user asked for options you are unsure about, run `$PARTCAD init --help`
+first. Report what the command created (typically `partcad.yaml`), and if it
+prints an error, surface that error verbatim rather than working around it.

--- a/ai-agents/common/skills/install/SKILL.md
+++ b/ai-agents/common/skills/install/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: install
+description: Install PartCAD (the `pc`/`partcad` command) so other skills can run it — either the standalone PyInstaller build from GitHub releases (`executable`) or the partcad-cli module into the active Python environment (`python-module`). Use when the user runs /pc:install or when PartCAD is not installed.
+---
+
+# pc:install
+
+Install PartCAD so `pc` and `partcad` become runnable. The argument selects how.
+It is in `$ARGUMENTS`; if empty or unrecognized, default to `executable` and say
+so.
+
+| Argument | Installs | Afterward it runs as |
+| --- | --- | --- |
+| `executable` | Standalone PyInstaller bundle from the latest GitHub release (no Python needed) | `pc` / `partcad` on `PATH` |
+| `python-module` | The `partcad-cli` module into the **active** Python environment | `python -m partcad_cli.click.command` |
+
+## 0. Skip if already installed
+
+Check whether PartCAD is already available, using the same resolution `/pc:init`
+uses; if so, report it and stop unless the user asked to reinstall:
+
+```sh
+command -v pc || command -v partcad || python -c "import partcad_cli" 2>/dev/null && echo "already installed"
+```
+
+## `executable` — standalone build from GitHub releases
+
+Defer to PartCAD's official POSIX installer, which finds the latest release,
+downloads the bundle for this OS/arch, verifies the checksum, and links `pc` /
+`partcad` into `~/.local/bin`:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/partcad/partcad/main/install.sh | sh
+```
+
+Options pass through the pipe with `sh -s --` (for example
+`... | sh -s -- --version 0.7.135`); the same knobs exist as environment
+variables (`PARTCAD_VERSION`, `PARTCAD_REPOSITORY`, `PARTCAD_BIN_DIR`, …).
+
+**There is no published standalone release yet.** Today the installer ends with a
+download 404:
+
+```
+error: download failed.
+       There may be no build of <version> for <platform>.
+```
+
+(or *"could not determine the latest release"* if there is no release at all).
+When the standalone bundle is not published, report that **no published PartCAD
+installer is available** and stop. Do not fall back to another install method and
+do not hand-roll one.
+
+## `python-module` — into the active Python environment
+
+Only when the user explicitly asks for this mode. Install the `partcad-cli`
+module with the current interpreter's pip (use `python3` if `python` is absent or
+Python 2):
+
+```sh
+python -m pip install -U partcad-cli
+```
+
+If pip refuses on a permissions or externally-managed-environment error, retry
+with `--user`, or use `pipx install partcad-cli` or a virtualenv. Verify and
+report the result, then suggest re-running the original task (for example
+`/pc:init`):
+
+```sh
+python -m partcad_cli.click.command --version
+```

--- a/ai-agents/scripts/materialize.sh
+++ b/ai-agents/scripts/materialize.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# Materialize the symlink-based Claude plugin (ai-agents/claude) into a
+# self-contained, SYMLINK-FREE artifact suitable for cross-platform
+# distribution.
+#
+# Why: the in-repo plugin shares its skills with ai-agents/common/skills via a
+# symlink. That is convenient for local use and works for macOS/Linux installs,
+# but git may not preserve symlinks on Windows checkouts, which would ship an
+# empty plugin. This script dereferences the symlink into real files so the
+# published artifact contains no symlinks at all.
+#
+# Requires no credentials. `claude plugin validate` runs fully offline.
+#
+# Usage:
+#   ai-agents/scripts/materialize.sh [OUT_DIR]
+#
+# Produces (default OUT_DIR = ai-agents/.build/marketplace):
+#   OUT_DIR/.claude-plugin/marketplace.json   catalog, source ./pc
+#   OUT_DIR/pc/.claude-plugin/plugin.json     the plugin manifest
+#   OUT_DIR/pc/skills/<name>/SKILL.md          real files (no symlinks)
+#   OUT_DIR/pc.zip                             plugin archive (if `zip` present)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+PLUGIN_NAME="pc"
+PLUGIN_SRC="$ROOT/ai-agents/claude"
+OUT_DIR="${1:-$ROOT/ai-agents/.build/marketplace}"
+
+if [ ! -f "$PLUGIN_SRC/.claude-plugin/plugin.json" ]; then
+  echo "ERROR: plugin manifest not found at $PLUGIN_SRC/.claude-plugin/plugin.json" >&2
+  exit 1
+fi
+
+echo "==> Materializing $PLUGIN_SRC -> $OUT_DIR/$PLUGIN_NAME (dereferencing symlinks)"
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR/.claude-plugin"
+
+# -R recursive, -L dereference every symlink into real files.
+cp -RL "$PLUGIN_SRC" "$OUT_DIR/$PLUGIN_NAME"
+
+# Hard guarantee for Windows: the artifact must contain zero symlinks.
+remaining="$(find "$OUT_DIR" -type l -print)"
+if [ -n "$remaining" ]; then
+  echo "ERROR: symlinks remain in the materialized artifact:" >&2
+  echo "$remaining" >&2
+  exit 1
+fi
+
+# Sanity: at least one skill must have come through the dereference.
+if ! find "$OUT_DIR/$PLUGIN_NAME/skills" -name SKILL.md -print -quit | grep -q .; then
+  echo "ERROR: no SKILL.md found under the materialized plugin" >&2
+  exit 1
+fi
+
+# Emit a marketplace catalog whose plugin source is the self-contained copy.
+cat > "$OUT_DIR/.claude-plugin/marketplace.json" <<JSON
+{
+  "\$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "partcad",
+  "description": "PartCAD skills for AI coding agents",
+  "owner": {
+    "name": "Roman Kuzmenko",
+    "email": "rkuz@partcad.org"
+  },
+  "plugins": [
+    {
+      "name": "$PLUGIN_NAME",
+      "description": "Mechanical and robotics engineering with PartCAD",
+      "source": "./$PLUGIN_NAME"
+    }
+  ]
+}
+JSON
+
+echo "==> Validating materialized marketplace"
+claude plugin validate "$OUT_DIR"
+
+if command -v zip >/dev/null 2>&1; then
+  ( cd "$OUT_DIR" && rm -f "$PLUGIN_NAME.zip" && zip -qr "$PLUGIN_NAME.zip" "$PLUGIN_NAME" )
+  echo "==> Wrote plugin archive: $OUT_DIR/$PLUGIN_NAME.zip"
+fi
+
+echo "==> Done. Symlink-free artifact at: $OUT_DIR"


### PR DESCRIPTION
## Summary

Adds `ai-agents/` — a vendor-neutral [Agent Skills](https://code.claude.com/docs/en/skills) library wrapped as a Claude Code plugin (`pc`), so PartCAD workflows are available to AI coding agents that open this repo.

- **`common/skills/`** — the tool-agnostic `SKILL.md` library (any `SKILL.md`-aware agent can consume it).
- **`claude/`** — the Claude plugin (`name: pc`); its `skills/` symlinks to `common/skills` (no duplication).
- **`.claude-plugin/marketplace.json`** (repo root) + **`.claude/skills/pc`** symlink — opening the repo auto-loads `pc@skills-dir`, so `/pc:*` is available with no install step.

## Skills

- **`/pc:init`** — `pc init` via the installed CLI (resolves `pc` / `partcad` / `python -m partcad_cli...`).
- **`/pc:install {executable|python-module}`** — standalone PyInstaller build (preferred) or the wheel.
- **`/pc:gen`, `/pc:gen-part`, `/pc:gen-assembly`** — the agent generates PartCAD parts/assemblies by authoring the CAD scripts / `.assy` files itself and validating with `pc test`/`pc render`. Supersedes the `pc add part --ai` pipeline and the VS Code "Generate with AI" flow — the agent is the model (no provider/API key) and may choose a different flow than the fixed CSG→script→render loop.

Both `/pc:gen-part` (L-bracket, centered holes) and `/pc:gen-assembly` (a pin on a base plate) were run end-to-end in the dev container: author → `pc test` → `pc render` → view → iterate.

## Shipping (Windows-safe)

`scripts/materialize.sh` dereferences the `skills` symlink into a self-contained artifact so a Windows `git`/plugin install never ships an empty plugin.

- `ai-agents.yml` — validates the catalog + plugin with `claude plugin validate` and asserts the artifact is symlink-free. **No credentials** (validation is offline).
- `ai-agents-release.yml` — on a `pc--v*` tag, publishes the symlink-free marketplace to a `plugin-dist` branch and attaches `pc.zip` to a Release, using only the automatic `GITHUB_TOKEN`.

## Companion fixes

The gen skills surfaced two core bugs, fixed separately: #470 (`pc render` crash on null `partcad.yaml` sections) and #471 (test-result cache ignored `manufacturable`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
