### PR TITLE
test(behave): skip @requires-network install-ssh scenario when offline

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -1,8 +1,40 @@
 import os
+import socket
+
 from allure_behave.hooks import allure_report
 
 
 from behave.runner import Context
+
+
+# Scenarios tagged with this require live outbound network access (e.g. an
+# SSH/HTTPS git clone from github.com). They are SKIPPED (not failed) when the
+# environment has no connectivity -- as in a sandboxed CI runner -- and run
+# normally when the network is reachable.
+NETWORK_TAG = "requires-network"
+
+
+def _network_available(host: str = "github.com", port: int = 443, timeout: float = 3.0) -> bool:
+    """Best-effort probe that outbound network to ``host:port`` works.
+
+    Deliberately fast and defensive: any failure (DNS error, refused
+    connection, timeout) -- or the ``PARTCAD_TEST_NO_NETWORK`` override -- is
+    treated as "no network" so the tagged scenario is skipped rather than
+    failing where connectivity is unavailable.
+    """
+    # Explicit override for offline/sandboxed CI, where even the probe may hang.
+    if os.environ.get("PARTCAD_TEST_NO_NETWORK"):
+        return False
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def before_scenario(context: Context, scenario) -> None:
+    if NETWORK_TAG in scenario.effective_tags and not _network_available():
+        scenario.skip("network not available: skipping @%s scenario" % NETWORK_TAG)
 
 
 # def before_all(context: Context) -> None:

--- a/features/install.feature
+++ b/features/install.feature
@@ -38,7 +38,9 @@ Feature: `pc install` command
     Then the command should exit with a status code of "0"
 
   # TODO: Investigate SSH-related hangs in Windows runners
-  @success @pc-init @pc-install @pc-ansi @skip-windows
+  # @requires-network: this clones from github.com; before_scenario in
+  # features/environment.py skips it when the network is unreachable.
+  @success @pc-init @pc-install @pc-ansi @skip-windows @requires-network
   Scenario: Install packages with ssh
     Given environment variable "PC_NO_ANSI" is set to "1"
     And a file named "partcad.yaml" with content:


### PR DESCRIPTION
## Problem

The behave scenario **"Install packages with ssh"** (`features/install.feature:42`) clones the
`partcad-electronics-sbcs-raspberrypi` repo from `github.com`. In a sandboxed or offline CI
runner that clone cannot reach the network, so the scenario **fails** — a lack of connectivity is
turned into a hard test failure rather than being tolerated.

We do not want to delete the scenario or hard-skip it unconditionally: when connectivity *is*
available (e.g. a normal developer machine or a networked CI job) it should still run and exercise
the SSH/`insteadOf` override path.

## Approach — conditional skip

- Tag the scenario `@requires-network` (alongside its existing tags).
- Add a `before_scenario` hook in `features/environment.py` that, for scenarios carrying that tag,
  runs a fast, defensive connectivity probe and calls `scenario.skip(...)` when the network is
  unreachable:
  - short-timeout (3s) TCP connection to `github.com:443`;
  - any failure (DNS, refused, timeout) is caught and treated as "no network";
  - an explicit `PARTCAD_TEST_NO_NETWORK` env override forces the skip without even probing, for
    fully offline runners where the probe itself could hang.

Result:
- **network present** → scenario runs exactly as before;
- **network absent** → scenario is counted as **skipped**, not failed;
- untagged scenarios are never affected, and the rest of the suite never depends on network.

This reuses the same in-hook `scenario.skip(...)` convention already used for the Windows-only
registry scenarios (`features/steps/.../windows_registry.py`).

## Validation

- Logic verified by simulating the `before_scenario` hook against fake scenario objects: tagged +
  offline → skipped; tagged + online → runs; untagged + offline → runs; `PARTCAD_TEST_NO_NETWORK`
  → forces skip. All cases pass.
- Fast pre-commit hooks (trailing-whitespace, end-of-file-fixer, etc.) pass on the changed files.
- Full `behave` was not run end-to-end from the isolated worktree (its venv/container is keyed to
  the main workspace); the PR's own CI exercises the scenario with real connectivity.

## Files changed

- `features/install.feature` — add `@requires-network` to the ssh scenario (+ a short explanatory comment).
- `features/environment.py` — add the `before_scenario` network-availability check and skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
