### PR TITLE
fix(behave): capture stderr separately in the healthcheck CliRunner

### DIFF
--- a/features/steps/partcad-cli/commands/healthcheck/common.py
+++ b/features/steps/partcad-cli/commands/healthcheck/common.py
@@ -7,12 +7,21 @@ from click.testing import CliRunner
 from partcad_cli.click.command import cli
 import partcad.logging  as pc_logging
 
-# Click 8.2 removed the 'mix_stderr' argument. It is not needed any more
-# either: a Result now always exposes 'stdout' and 'stderr' separately, which
-# is what passing mix_stderr=False used to buy. Only 'output' changed meaning -
-# it is the two interleaved now rather than stdout alone - and the sole use
-# below is an error message, which is better off with both.
-runner = CliRunner()
+# Capture stdout and stderr separately so the shared assertion steps in
+# features/steps/partcad-cli/commands/version.py can read context.result.stderr
+# (they log it for debugging) without click raising "stderr not separately
+# captured".
+#
+# Click 8.2 removed the 'mix_stderr' argument and a Result now always exposes
+# 'stdout' and 'stderr' separately, which is exactly what mix_stderr=False used
+# to buy. On click < 8.2, however, the default is mix_stderr=True: stderr is
+# folded into stdout and Result.stderr raises, so mix_stderr=False must be
+# passed there. Construct the runner in a way that works on both.
+try:
+    runner = CliRunner(mix_stderr=False)
+except TypeError:
+    # click >= 8.2 no longer accepts (or needs) mix_stderr.
+    runner = CliRunner()
 
 def healthcheck_cli(context, options: List[str] = []):
     patches = []


### PR DESCRIPTION
## Problem

`poetry run behave features/healthcheck.feature` fails 4 scenarios, each with:

```
File "features/steps/partcad-cli/commands/version.py", line 35, in step_impl
    logging.info(f"STDERR: {strip_ansi(context.result.stderr)}")
  File ".../click/testing.py", line 150, in stderr
    raise ValueError("stderr not separately captured")
ValueError: stderr not separately captured
```

## Root cause

The healthcheck steps invoke the CLI through click's `CliRunner`. The dependency-refresh
commit `a7bcd3b3` replaced `CliRunner(mix_stderr=False)` with a bare `CliRunner()`, on the
premise that "a Result now always exposes stdout and stderr separately" under click 8.2.

That premise only holds on click **>= 8.2**. On click **< 8.2** the `CliRunner()` default is
`mix_stderr=True`, which folds stderr into stdout and leaves `Result.stderr_bytes` as `None`, so
reading `Result.stderr` raises `ValueError("stderr not separately captured")` (the exact line 150
in the traceback).

The shared assertion steps in `features/steps/partcad-cli/commands/version.py` log
`context.result.stderr` for debugging on every `STDOUT should contain` check, so under click 8.1.x
every non-Windows healthcheck scenario blows up there before it can assert anything. The generic
`features/steps/run.py` step is unaffected because it shells out via `subprocess.run(capture_output=True)`
and captures the two streams itself — which is the behavior the healthcheck step needs to match.

## Fix

Restore separate stderr capture in a version-tolerant way in
`features/steps/partcad-cli/commands/healthcheck/common.py`:

```python
try:
    runner = CliRunner(mix_stderr=False)
except TypeError:
    # click >= 8.2 no longer accepts (or needs) mix_stderr.
    runner = CliRunner()
```

This reinstates the pre-refactor semantics — `stdout` holds only stdout, `stderr` is separately
captured and readable — on click 8.1.x, and keeps working on click 8.2+ (where the default already
separates the streams). No assertion is weakened and no STDERR logging is removed; only the
`CliRunner` construction changes.

## Validation

Running behave from the isolated worktree against the shared dev-container `.venv` was impractical
(the venv/container are keyed to the main workspace path), so the fix was validated by direct
reproduction against both click lines:

- **click 8.1.8** (the version producing the reported traceback): the bare `CliRunner()` reproduces
  `ValueError: stderr not separately captured`; with the fix, `CliRunner(mix_stderr=False)` is used,
  `result.stderr` reads cleanly, and `result.stdout` contains only the stdout content the
  `STDOUT should contain` steps assert on.
- **click 8.4.2** (the pinned version): the `TypeError` fallback selects the default `CliRunner()`,
  `result.stderr` reads cleanly, and `result.stdout` is likewise stdout-only.

This PR's own CI (which runs the full behave suite) is the end-to-end check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
