### PR TITLE
ci(vscode): fix extension test on macOS (Electron ENOENT) and stop fail-fast masking Linux

### DIFF
--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -15,6 +15,10 @@ on:
 jobs:
   build:
     strategy:
+      # Don't let one OS failing cancel the other: a green Linux run was being
+      # reported as failed only because it was canceled when the macOS job
+      # failed. Keep both statuses independent (matches build.yml).
+      fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest] # windows-latest for some reason doesn't run test suite.
     runs-on: ${{ matrix.os }}

--- a/partcad-ide-vscode/package-lock.json
+++ b/partcad-ide-vscode/package-lock.json
@@ -22,7 +22,7 @@
         "@typescript-eslint/eslint-plugin": "^8.65.0",
         "@typescript-eslint/parser": "^8.65.0",
         "@vscode/test-cli": "^0.0.15",
-        "@vscode/test-electron": "^3.0.0",
+        "@vscode/test-electron": "^3.1.0",
         "@vscode/vsce": "^3.9.2",
         "eslint": "^9.39.5",
         "glob": "^13.0.6",
@@ -1563,9 +1563,9 @@
       }
     },
     "node_modules/@vscode/test-electron": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-3.0.0.tgz",
-      "integrity": "sha512-TY5mC7aAjxSLDXsyjhrG8cJHgc/HLdiE5lvtW7hABYQrY24Qwozzr5UoO3HiuAM4Hzz4b7K/eZlwrCILj94CcA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-3.1.0.tgz",
+      "integrity": "sha512-CRqv5u+YYoseuNVJ6Tyo4k0sF0mx4qnKMihRB0PjsUF8Dc0WKtCXo6CNL6nWWm5esfFQsQA/pejMj4ZbpJVLTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9215,9 +9215,9 @@
       }
     },
     "@vscode/test-electron": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-3.0.0.tgz",
-      "integrity": "sha512-TY5mC7aAjxSLDXsyjhrG8cJHgc/HLdiE5lvtW7hABYQrY24Qwozzr5UoO3HiuAM4Hzz4b7K/eZlwrCILj94CcA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-3.1.0.tgz",
+      "integrity": "sha512-CRqv5u+YYoseuNVJ6Tyo4k0sF0mx4qnKMihRB0PjsUF8Dc0WKtCXo6CNL6nWWm5esfFQsQA/pejMj4ZbpJVLTw==",
       "dev": true,
       "requires": {
         "http-proxy-agent": "^7.0.2",

--- a/partcad-ide-vscode/package.json
+++ b/partcad-ide-vscode/package.json
@@ -903,7 +903,7 @@
     "@typescript-eslint/eslint-plugin": "^8.65.0",
     "@typescript-eslint/parser": "^8.65.0",
     "@vscode/test-cli": "^0.0.15",
-    "@vscode/test-electron": "^3.0.0",
+    "@vscode/test-electron": "^3.1.0",
     "@vscode/vsce": "^3.9.2",
     "eslint": "^9.39.5",
     "glob": "^13.0.6",


### PR DESCRIPTION
## Problem

The `npm test` workflow (VS Code extension harness) has been red on every PR. Both matrix jobs showed as failed, but for two different reasons.

### macOS (`build (macos-latest)`) — the real failure

`npm test` died with:

```
Test error: Error: spawn .../.vscode-test/vscode-darwin-arm64-1.131.0/Visual Studio Code.app/Contents/MacOS/Electron ENOENT
Exit code: -2
```

`@vscode/test-electron@3.0.0` hardcodes the macOS launch path as `Visual Studio Code.app/Contents/MacOS/Electron`. VS Code **1.110** renamed that main binary from the historical `Electron` to the product name (`Code`) in `microsoft/vscode#291948`, and the compatibility `Electron` symlink was later removed in `microsoft/vscode#326502`. So downloading **any 1.110+ build** (the runner fetched `1.131.0`) leaves no `Electron` file and the spawn fails with `ENOENT`.

`@vscode/test-electron@3.1.0` fixes this (`microsoft/vscode-test#348`/`#349`): it resolves the real executable from the app bundle's `Info.plist` (`CFBundleExecutable`), falling back to the sole binary in `Contents/MacOS/` and finally the legacy `Electron` name. The change is confined to the darwin branch of `downloadDirToExecutablePath`; Linux/Windows resolution is byte-for-byte identical between 3.0.0 and 3.1.0.

### Linux (`build (ubuntu-latest)`) — not actually failing

The ubuntu job already runs under `xvfb-run -a`, activates the extension, and the suite passes:

```
✔ Extension activation
✔ Command registration
2 passing (14s)
Exit code: 0
```

It was only reported as failed because the matrix's default `fail-fast: true` **cancelled** it the moment the macOS job died (`The operation was canceled.`).

## Fix

- Bump `@vscode/test-electron` to `^3.1.0` in `partcad-ide-vscode/package.json` and `package-lock.json` (3.1.0 has the same transitive deps as 3.0.0, so the lockfile change is just the version/integrity of that one package).
- Set `fail-fast: false` on the `npm test` matrix so a red macOS job no longer cancels a green Linux job and hides its real status (matches the pattern already used in `build.yml`).

No product code touched (`partcad/src` untouched); changes are limited to the extension's dev dependency and the CI workflow.

## Validation

- Confirmed via the actual CI logs that macOS fails with the `Electron ENOENT` on the `1.131.0` download, and that ubuntu reaches `2 passing` / exit 0 before being cancelled.
- Diffed the `@vscode/test-electron` 3.0.0 → 3.1.0 sources: the only runtime change is the darwin executable-resolution logic described above.
- Ran the repo's `pre-commit` hooks against the changed files: `check-yaml`, `Validate GitHub Workflows`, trailing-whitespace / end-of-file all pass.
- The macOS-arm64 runtime path itself can only be exercised on a macOS-arm64 runner, so final confirmation is left to this PR's CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
