### PR TITLE
ci(macos): re-assert VTK-enabled cadquery-ocp last in the CI test env (speculative segfault fix)

### DIFF
--- a/.github/actions/setup-all/action.yml
+++ b/.github/actions/setup-all/action.yml
@@ -201,6 +201,20 @@ runs:
         python -m pip install --upgrade ./partcad-cli
         python -m pip install --upgrade -r partcad-cli/requirements-dev.txt
         python -m pip install --upgrade -r partcad-ide-vscode/src/test/python_tests/requirements.txt
+        # Re-assert the VTK-enabled cadquery-ocp LAST. build123d (installed above
+        # via requirements-dev.in) depends on 'cadquery-ocp-novtk', which writes
+        # the very same OCP native module as 'cadquery-ocp' but compiled without
+        # VTK. The two are separate distributions that overwrite each other, and
+        # pip resolves a '-r' file as one dependency graph -- it does NOT honour
+        # the line order in that file -- so which build lands last is undefined.
+        # A novtk/VTK mismatch segfaults the in-process CAD stack on the macOS
+        # runners (the tests that import OCP/build123d/cadquery directly). Force
+        # the VTK build to win, mirroring the sandbox re-assert (CADQUERY_OCP is
+        # installed last there -- see partcad/src/partcad/sandbox_versions.py and
+        # runtime_python.FORCE_REINSTALL_FLAGS). Deliberately WITHOUT '--no-deps':
+        # the VTK-enabled module needs its 'vtk' dependency present to load. The
+        # pin is read back from requirements-dev.in to keep it single-sourced.
+        python -m pip install --force-reinstall "$(grep -E '^cadquery-ocp==' partcad/requirements-dev.in)"
         mamba deactivate
 
         # echo "PC_INTERNAL_STATE_DIR=$(mktemp -d)" >> $GITHUB_ENV

--- a/partcad/requirements-dev.in
+++ b/partcad/requirements-dev.in
@@ -27,3 +27,9 @@ nox-poetry==1.2.0
 cadquery-ocp==7.9.3.1.1
 build123d==0.11.1
 ocpsvg==0.6.0
+# ORDER NOTE: build123d depends on 'cadquery-ocp-novtk', which writes the same
+# OCP native module as 'cadquery-ocp' but without VTK. pip resolves this file as
+# one dependency graph and does NOT honour the line order above, so the CI test
+# env re-asserts the VTK-enabled cadquery-ocp last with '--force-reinstall'
+# (.github/actions/setup-all/action.yml), mirroring the sandbox re-assert in
+# sandbox_versions.py (GUARD_INVALIDATED_BY / CADQUERY_OCP installed last).


### PR DESCRIPTION
## Speculative fix for the macOS `Segmentation fault: 11` seen on PR #478

**This is a speculative experiment, not a confirmed fix.** It cannot be validated on macOS locally, so it relies entirely on this PR's CI. The signal to watch is whether the **macOS Pytest** jobs still segfault.

> Base note: PR #478 has since squash-merged into `devel` and its branch was deleted, so this PR targets **`devel`**, which now carries the exact pre-fix state described below.

### What the investigation found

PR #478 added the CAD trio to `partcad/requirements-dev.in` (`cadquery-ocp==7.9.3.1.1`, `build123d==0.11.1`, `ocpsvg==0.6.0`) so pytest can import OCP/build123d/cadquery directly. The macOS Pytest/Examples/Behave jobs then crash with `Fatal Python error: Segmentation fault: 11` (Linux and Windows pass).

`build123d` depends on `cadquery-ocp-novtk`, which writes the **same** OCP native module as `cadquery-ocp` but compiled **without** VTK. They are separate distributions that overwrite each other on disk, so whichever pip installs *last* wins. The in-tree sandboxes handle this deliberately: `sandbox_versions.GUARD_INVALIDATED_BY` plus `runtime_python` re-assert (force-reinstall) `cadquery-ocp` **last**, after `build123d` — "every install list ends with `CADQUERY_OCP`".

The CI **test env** did not do this. `.github/actions/setup-all/action.yml` installs the whole trio in a single `python -m pip install -r partcad/requirements-dev.in`. pip resolves a requirements file as one dependency graph and **does not honour the line order** in the file, so which of `cadquery-ocp` / `cadquery-ocp-novtk` lands last is undefined. (Nothing installed afterward — `partcad-cli`, `allure-behave`, the IDE test reqs — pulls OCP/build123d, so `requirements-dev.in` is the only thing that can clobber it.) A novtk/VTK mismatch is a plausible cause of a native crash with no Python traceback on macOS.

### The change (CI/dep files only — no `partcad/src`)

- `.github/actions/setup-all/action.yml`: after the requirements installs, force-reinstall the VTK-enabled `cadquery-ocp` **last**, mirroring the sandbox re-assert. Deliberately **without** `--no-deps` (the VTK module needs its `vtk` dependency present to load, matching `runtime_python.FORCE_REINSTALL_FLAGS`). The pin is read back from `requirements-dev.in` with `grep` to stay single-sourced.
- `partcad/requirements-dev.in`: a comment documenting that pip ignores the line order and that the re-assert lives in `setup-all/action.yml`.

### Honest caveat

If CI shows macOS Pytest **still** segfaults after this, the install order was not the cause and this points at a genuine macOS OCP-7.9 native bug rather than a packaging-order problem. In that case this PR should be closed, not merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
