### PR TITLE
fix(core): mark part failed on extrude/sweep sandbox errors

### DIFF
--- a/partcad/src/partcad/part_factory_extrude.py
+++ b/partcad/src/partcad/part_factory_extrude.py
@@ -94,5 +94,6 @@ class PartFactoryExtrude(PartFactory):
                 self.ctx.stats_parts_instantiated += 1
                 return result["shape"]
             except Exception as e:
+                part.error("%s: %s: failed to create an extruded part: %s" % (part.project_name, part.name, e))
                 pc_logging.exception("Failed to create an extruded part: %s" % e)
                 return None

--- a/partcad/src/partcad/part_factory_sweep.py
+++ b/partcad/src/partcad/part_factory_sweep.py
@@ -109,5 +109,6 @@ class PartFactorySweep(PartFactory):
                 self.ctx.stats_parts_instantiated += 1
                 return result["shape"]
             except Exception as e:
+                part.error("%s: %s: failed to create a swept part: %s" % (part.project_name, part.name, e))
                 pc_logging.exception(f"Failed to create a swept part: {e}")
                 return None


### PR DESCRIPTION
## Summary

Addresses the CodeRabbit "Major" review comment on #478.

In `part_factory_extrude.py` and `part_factory_sweep.py`, the `instantiate()` method now runs the CAD operation in a sandbox and wraps the whole body in a `try`/`except`. The outer `except` only called `pc_logging.exception(...)` and returned `None` — it did **not** call `part.error(...)`.

Every sibling factory (and the other failure branches inside these same two methods — the "no shape" branch and the `result["success"]` branch) marks the part failed via `part.error(...)`. The passing pattern lives in `part_factory_sdf.py`, whose compound branch calls `part.error(...)` then returns `None`.

Because of the gap, a runtime-install or sandbox-spawn failure (e.g. `runtime.ensure_async`, `runtime.run_async`, or the explicit `raise Exception(errors)`) returned `None` while leaving the part unmarked as failed, so downstream consumers could not tell the instantiation had actually failed. This is a broken-contract bug relative to every other part factory.

## Fix

In the outer `except` of both factories, call `part.error(...)` — naming the part (`project_name:name`) and the failure — before `pc_logging.exception(...)`, then return `None`. The `part` object is the `instantiate` method parameter and is in scope. The message style matches the existing `part.error(...)` calls in the same files.

```python
except Exception as e:
    part.error("%s: %s: failed to create an extruded part: %s" % (part.project_name, part.name, e))
    pc_logging.exception("Failed to create an extruded part: %s" % e)
    return None
```

(analogous change for the swept part in `part_factory_sweep.py`)

## Scope

Only the two factory files, one line added to each. No behavior change on the success path.

## Validation

Run in the dev container:
- `black --check` and `isort --check-only`: pass on both files.
- AST parse + `import partcad.part_factory_extrude, partcad.part_factory_sweep`: OK.
- `pytest -k "extrude or sweep"`: no dedicated unit tests exist for these factories (0 collected); they are exercised through the behave integration suite.

## Base

Targets `devel`. The sandbox-wrapper code these files fix was introduced by #478, which merged into `devel` while this fix was in progress; `devel` now carries the affected `instantiate()` methods, so this follow-up applies as a single clean commit on top of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
