### PR TITLE
build(pyinstaller): refuse to freeze a non-PyPI _cffi_backend on macOS arm64

### DIFF
--- a/dev-tools/pyinstaller/README.md
+++ b/dev-tools/pyinstaller/README.md
@@ -39,6 +39,23 @@ PYTHON=/tmp/pyi-venv/bin/python dev-tools/pyinstaller/build.sh
 Pass `--no-install` to skip the dependency step when the environment is already prepared, and `--no-archive` to
 stop after the bundle and skip packing it.
 
+On an Apple silicon Mac, build from a **non-conda** interpreter. PartCAD needs conda for the CAD sandbox, so a
+conda `python3` is usually first on `PATH` — and freezing from one produces a bundle that segfaults. `pygit2`
+reads the libgit2 config search path through a variadic C call, which cffi dispatches at run time through
+`_cffi_backend`; the conda-forge cffi 2.x build mis-marshals variadic arguments on Apple arm64 (the PyPI wheel,
+linked against Apple's system libffi, does not). Nothing catches it downstream: the crashing path only runs
+when a clone fails to authenticate and PartCAD retries it with the ambient git config ignored, so the bundle
+passes every check and then crashes for users. `build.sh` refuses to freeze a `_cffi_backend` that is not the
+PyPI build; if it does, either build from a plain `python.org`/`pyenv` interpreter or force the wheel in:
+
+```bash
+python -m pip install --upgrade --force-reinstall --no-deps --only-binary=:all: cffi
+```
+
+CI is not exposed to this — `build-standalone.yml` provisions Python with `actions/setup-python`, which has no
+conda anywhere near it. The same crash in the *wheel*-based CI jobs, whose runners do use conda, is handled
+separately in `.github/actions/setup-all/action.yml`.
+
 The results land in `dist/standalone/`: the `partcad/` bundle, an archive named
 `partcad-<version>-<os>-<arch>.tar.gz` (`.zip` on Windows), and its `.sha256`. The archive name is a contract
 with `install.sh`, which derives the same name from `uname`.

--- a/dev-tools/pyinstaller/build.sh
+++ b/dev-tools/pyinstaller/build.sh
@@ -299,6 +299,68 @@ if broken:
     sys.exit(1)
 PREFLIGHT
 
+# The other way this build environment can produce a bundle that looks complete
+# and is not: on Apple arm64, `_cffi_backend` has to be the PyPI build.
+#
+# `pygit2` reads the libgit2 config search path through
+# `git_libgit2_opts(GIT_OPT_GET_SEARCH_PATH, level, git_buf *)`, a variadic C
+# call that cffi cannot wrap statically and so dispatches at run time through
+# `_cffi_backend`/libffi. Apple arm64 passes variadic arguments on the stack
+# rather than in registers, and the conda-forge cffi 2.x build mis-marshals them
+# there: libgit2 is handed a garbage pointer to write through and the process
+# segfaults. The PyPI wheel links Apple's system libffi and marshals them
+# correctly, which is why the wheels are unaffected. Distinguishing the two is
+# exactly this: the PyPI build loads '/usr/lib/libffi.dylib', the conda-forge
+# build loads '@rpath/libffi.8.dylib' from its own prefix.
+#
+# CI builds with `actions/setup-python`, so it always gets the PyPI wheel. A
+# developer building on their own Mac is the exposed case: PartCAD needs conda
+# for the CAD sandbox, so a conda `python3` is usually first on PATH, its cffi
+# already satisfies `pygit2`'s floor (so pip leaves it in place), and PyInstaller
+# then freezes both that `_cffi_backend` and the conda `libffi.8.dylib` beside
+# it. The bundle's own CI cannot catch this: the crashing path only runs when a
+# clone fails to authenticate and PartCAD retries it with the ambient git config
+# ignored (`_clone_ignoring_ambient_config` in `partcad/project_factory_git.py`),
+# which no anonymous clone of a public repository reaches. It would ship, and
+# segfault for users only.
+if [ "${PLATFORM}" = "macos-arm64" ]; then
+  echo "==> Checking that _cffi_backend is the PyPI build"
+  # Read with macholib rather than `otool`, so this needs no Xcode command line
+  # tools; PyInstaller depends on macholib, so it is already installed.
+  "${PYTHON}" - <<'CFFI_PROVENANCE'
+import _cffi_backend
+from macholib.MachO import MachO
+from macholib.mach_o import LC_LOAD_DYLIB, LC_LOAD_WEAK_DYLIB
+
+SYSTEM_LIBFFI = "/usr/lib/libffi.dylib"
+
+loaded = []
+for header in MachO(_cffi_backend.__file__).headers:
+    for load_command, _command, data in header.commands:
+        if load_command.cmd in (LC_LOAD_DYLIB, LC_LOAD_WEAK_DYLIB):
+            loaded.append(data.decode("utf-8").rstrip("\0"))
+
+if SYSTEM_LIBFFI not in loaded:
+    print(f"error: '{_cffi_backend.__file__}'")
+    print(f"       does not load {SYSTEM_LIBFFI}, it loads:")
+    print("\n".join(f"         {name}" for name in loaded))
+    print()
+    print("       This is not the PyPI cffi wheel. A conda-forge build mis-marshals")
+    print("       variadic arguments on Apple arm64, which makes pygit2 segfault when")
+    print("       PartCAD retries a clone with the ambient git config ignored -- and")
+    print("       freezing it here would ship that crash to every user of the bundle.")
+    print()
+    print("       Build from a non-conda interpreter, or force the PyPI wheel into")
+    print("       this environment:")
+    print()
+    print("         python -m pip install --upgrade --force-reinstall --no-deps \\")
+    print("             --only-binary=:all: cffi")
+    raise SystemExit(1)
+
+print(f"    {_cffi_backend.__file__} loads {SYSTEM_LIBFFI}")
+CFFI_PROVENANCE
+fi
+
 ################################################  FREEZE  ####################################################
 
 echo "==> Freezing"


### PR DESCRIPTION
## Context

#484 fixes the `pygit2` Apple-arm64 segfault for the **wheel-based** CI jobs, whose runners provision Python
with conda. This PR answers the follow-up question: does the **PyInstaller bundle** need the same fix?

**It does not — but a local macOS build can still ship the crash, so this adds a guard for that.** No part of
#484 is duplicated here; the two changes touch disjoint files and can land in either order.

## Why the bundle is not exposed

The bug is entirely about *which build of `_cffi_backend`* is present. `build-standalone.yml` provisions Python
with `actions/setup-python@v7` and `build.sh` installs with plain `pip`, so conda is never in the picture. The
macOS build log confirms the resolution:

```
Downloading cffi-2.1.0-cp314-cp314-macosx_11_0_arm64.whl (184 kB)
Requirement already satisfied: cffi>=2.0 in
  /Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/site-packages (2.1.0)
```

Verified on the artifact itself rather than inferred from the workflow — the Mach-O load commands of the
shipped `partcad-standalone-macos-arm64` (0.7.148):

| binary | `LC_LOAD_DYLIB` for libffi |
| --- | --- |
| `partcad/_internal/_cffi_backend.cpython-314-darwin.so` (shipped bundle) | `/usr/lib/libffi.dylib` |
| PyPI `cffi-2.1.0-cp314-…-macosx_11_0_arm64.whl` | `/usr/lib/libffi.dylib` |
| conda-forge `cffi-2.1.0-py314h1dbec7b_0.conda` (osx-arm64) | `@rpath/libffi.8.dylib` |

The shipped `_cffi_backend` is the PyPI build — identical load commands and command count, bytes differing only
because PyInstaller re-signs it. The bundle also contains **no `libffi.*.dylib` at all**: PyInstaller excluded
Apple's as a system library, so at run time it binds the system libffi, which marshals varargs correctly. Had
the build been done in a conda env, `@rpath/libffi.8.dylib` is not a system library and PyInstaller *would*
have collected it into the bundle.

`pygit2`'s own wheel cannot reintroduce the problem either: `pygit2-1.19.3-…-macosx_11_0_arm64.whl` vendors
only libgit2/libssh2/libcrypto in `.dylibs/`, no libffi. The variadic dispatch lives purely in `_cffi_backend`.

## What this PR changes, and why anything changes at all

Green macOS bundle CI is *not* what proves the above, which is the reason for the guard. The search path is
read only inside `_AmbientConfigGuard.ignoring_ambient_config()` (`partcad/src/partcad/project_factory_git.py`),
reached only from `_clone_ignoring_ambient_config()` after `is_auth_failure(e)`. The
`Examples … via bundle (macos-arm64)` job clones public repositories anonymously and succeeds, so it never
enters that path. **A broken bundle would pass every job in `build-standalone.yml` and segfault for users only.**

CI is safe; a developer's Mac is not. `dev-tools/pyinstaller/README.md` tells developers to build on their own
machine, and a PartCAD developer's Mac almost certainly has Miniforge first on `PATH` — conda is a PartCAD
runtime prerequisite. If `PYTHON` resolves to that interpreter, its `cffi 2.1.0` already satisfies `pygit2`'s
`cffi>=2.0`, pip leaves it alone, and PyInstaller freezes the mis-marshalling `_cffi_backend` plus
`libffi.8.dylib` into a bundle that then ships.

So, on `macos-arm64` only:

- **`build.sh`** — a pre-flight check that `_cffi_backend` loads `/usr/lib/libffi.dylib`, alongside the existing
  imported-by-name check, which is there for exactly the same class of failure (a bundle that looks complete
  and is broken on one code path). It reads the load commands with `macholib` rather than `otool`, so it needs
  no Xcode command line tools — `macholib` is a PyInstaller dependency and is already installed. The failure
  message names the offending file, lists what it actually loads, and gives the force-reinstall command.
- **`README.md`** — the same hazard written down where the build instructions are, since the guard tells you
  what went wrong but not why building from conda is so easy to do by accident.

A provenance assert rather than #484's unconditional force-reinstall: in CI the reinstall would be a no-op on
every run, and the failure mode being defended against here is a wrong *interpreter choice*, which is worth
saying out loud rather than silently repairing.

## Validation

- Extracted the guard body and ran it against three real binaries: the PyPI wheel's `_cffi_backend` (passes),
  the one from the shipped `macos-arm64` bundle (passes), and the conda-forge `osx-arm64` build (fails, exit 1,
  with the intended message). This is what the table above was produced from.
- `bash -n` clean; `pre-commit run --config dev-tools/pre-commit-config.yaml` passes, both `shellcheck` hooks
  included.
- The guard itself cannot run on this Linux dev container — it is gated on `PLATFORM = macos-arm64`, so the
  `Standalone` workflow's macOS build is what exercises it end to end. The Linux and Windows bundles are
  untouched: x86_64 passes variadic arguments in registers and is unaffected by the underlying bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
