### PR TITLE
fix(runtime): serialize a session v-env's installs and its run (cadquery/OCP race)

### DIFF
--- a/partcad/src/partcad/runtime_python.py
+++ b/partcad/src/partcad/runtime_python.py
@@ -358,12 +358,24 @@ class PythonRuntime(runtime.Runtime):
         return self.run_onced(cmd, stdin=stdin, cwd=cwd, session=session)
 
     def run_onced(self, cmd, stdin="", cwd=None, session=None, path=None):
-        if session and session["dirty"]:
-            # The venv environment has to be created
-            venv_created = False
-            with self.sync_lock():
-                if not os.path.exists(session["path"]):
-                    venv_created = True
+        # Hold the venv-scoped lock across BOTH provisioning and execution so a
+        # session's package installs and its interpreter run are one atomic
+        # critical section. Two parts of the same package (e.g. a CadQuery part
+        # and a build123d part) share a session v-env; if the install loop is
+        # left outside this lock, a build123d install -- which pulls
+        # 'cadquery-ocp-novtk' and overwrites the shared OCP native module --
+        # can slip in between another part's CADQUERY_OCP re-assertion and the
+        # moment that part actually runs "import cadquery", leaving it to import
+        # a novtk/half-installed OCP and fail with an unrelated-looking
+        # ImportError (e.g. a missing 'vtkmodules'). The guard bookkeeping makes
+        # the VTK build win once all installs settle, but not necessarily at the
+        # instant a run starts; serializing install+run per v-env closes that
+        # window. See run_async_onced() for the async twin.
+        with self.sync_lock(session):
+            if session and session["dirty"]:
+                # The venv environment has to be created
+                venv_created = not os.path.exists(session["path"])
+                if venv_created:
                     with pc_logging.Action("v-env", self.version, session["name"]):
                         # Create the venv environment
                         pc_logging.debug("Creating venv: %s" % session["path"])
@@ -375,15 +387,18 @@ class PythonRuntime(runtime.Runtime):
                                 session["path"],
                             ]
                         )
-            # Install of the dependencies into the venv environment
-            for dep in session["deps"]:
-                if dep == "partcad":
-                    dep = get_local_partcad_pkg(dep)
-                self.ensure_onced(dep, path=session["path"])
-            if venv_created:
-                self.check_deps_onced_locked(path=session["path"])
+                # Install the dependencies into the venv. We already hold the
+                # venv lock, so use the *_locked ensure and take the install
+                # lock explicitly; the resulting order (venv lock, then the
+                # conda global lock) matches once()/ensure and cannot deadlock.
+                with self.sync_lock_install():
+                    for dep in session["deps"]:
+                        if dep == "partcad":
+                            dep = get_local_partcad_pkg(dep)
+                        self.ensure_onced_locked(dep, path=session["path"])
+                    if venv_created:
+                        self.check_deps_onced_locked(path=session["path"])
 
-        with self.sync_lock(session):
             python_path = self.get_venv_python_path(session, path)
             cmd = [python_path, *self.python_flags, *cmd]
             pc_logging.debug("Running: %s", cmd)
@@ -489,12 +504,24 @@ class PythonRuntime(runtime.Runtime):
         return await self.run_async_onced(cmd, stdin=stdin, cwd=cwd, session=session)
 
     async def run_async_onced(self, cmd, stdin="", cwd=None, session=None, path=None):
-        if session and session["dirty"]:
-            # The venv environment has to be created
-            venv_created = False
-            async with self.async_lock():
-                if not os.path.exists(session["path"]):
-                    venv_created = True
+        # Hold the venv-scoped lock across BOTH provisioning and execution so a
+        # session's package installs and its interpreter run are one atomic
+        # critical section. Two parts of the same package (e.g. a CadQuery part
+        # and a build123d part) share a session v-env; if the install loop is
+        # left outside this lock, a build123d install -- which pulls
+        # 'cadquery-ocp-novtk' and overwrites the shared OCP native module --
+        # can slip in between another part's CADQUERY_OCP re-assertion and the
+        # moment that part actually runs "import cadquery", leaving it to import
+        # a novtk/half-installed OCP and fail with an unrelated-looking
+        # ImportError (e.g. a missing 'vtkmodules'). The guard bookkeeping makes
+        # the VTK build win once all installs settle, but not necessarily at the
+        # instant a run starts; serializing install+run per v-env closes that
+        # window.
+        async with self.async_lock(session):
+            if session and session["dirty"]:
+                # The venv environment has to be created
+                venv_created = not os.path.exists(session["path"])
+                if venv_created:
                     with pc_logging.Action("v-env", self.version, session["name"]):
                         # Create the venv environment
                         pc_logging.debug("Creating venv: %s" % session["path"])
@@ -506,16 +533,18 @@ class PythonRuntime(runtime.Runtime):
                                 session["path"],
                             ]
                         )
+                # Install the dependencies into the venv. We already hold the
+                # venv lock, so use the *_locked ensure and take the install
+                # lock explicitly; the resulting order (venv lock, then the
+                # conda global lock) matches once()/ensure and cannot deadlock.
+                with self.sync_lock_install():
+                    for dep in session["deps"]:
+                        if dep == "partcad":
+                            dep = get_local_partcad_pkg(dep)
+                        await self.ensure_async_onced_locked(dep, path=session["path"])
+                    if venv_created:
+                        await self.check_deps_async_onced_locked(path=session["path"])
 
-            # Install of the dependencies into the venv environment
-            for dep in session["deps"]:
-                if dep == "partcad":
-                    dep = get_local_partcad_pkg(dep)
-                await self.ensure_async_onced(dep, path=session["path"])
-            if venv_created:
-                await self.check_deps_async_onced_locked(path=session["path"])
-
-        async with self.async_lock(session):
             python_path = self.get_venv_python_path(session, path)
             cmd = [python_path, *self.python_flags, *cmd]
             pc_logging.debug("Running: %s", cmd)

--- a/partcad/src/partcad/sandbox_versions.py
+++ b/partcad/src/partcad/sandbox_versions.py
@@ -80,6 +80,15 @@ EZDXF = "ezdxf==1.4.4"
 # Every install list in this package therefore ends with CADQUERY_OCP, so the
 # re-assertion happens within the same sequence rather than at some arbitrary
 # later point.
+#
+# The re-assertion makes the VTK build win once a sandbox's installs have all
+# settled, but it does not by itself guarantee the VTK build is the one on disk
+# at the instant an interpreter starts. When a CadQuery part and a build123d
+# part of the same package share a session v-env and render concurrently, a
+# build123d (novtk) install must not slip in between another part's re-assertion
+# and its "import cadquery". runtime_python.run_onced / run_async_onced close
+# that window by serializing a session's installs and its run under one v-env
+# lock.
 GUARD_INVALIDATED_BY = {
     BUILD123D: (CADQUERY_OCP,),
 }


### PR DESCRIPTION
## Summary

Fixes the intermittent, cross-platform CI failures where **cadquery** conversions
die at `import cadquery` with unrelated-looking errors — `OCP.TopoDS.TopoDS has
no attribute 'Vertex'`, a missing `vtkmodules`, etc. — most visible on the
`Examples` jobs, randomly across Linux, Windows and macOS run-to-run.

## Root cause: an install-vs-run race on a shared session v-env

A CadQuery part and a build123d part of the same package share a **session
v-env**. In `PythonRuntime.run_onced()` / `run_async_onced()`, the dependency
**install loop ran outside** the v-env lock, while the interpreter run took the
lock separately. So a build123d install — which pulls `cadquery-ocp-novtk` and
**overwrites the shared OCP native module** with a VTK-less build — could slip in
**between** another part's `cadquery-ocp` re-assertion (the `GUARD_INVALIDATED_BY`
bookkeeping) and the instant that part actually ran `import cadquery`, leaving it
importing a novtk/half-installed OCP.

`GUARD_INVALIDATED_BY` makes the VTK build win once a sandbox's installs *settle*
— but not necessarily at the moment a run *starts*. That timing window is the
bug, which is why it was intermittent.

## Fix

Hold the v-env lock across **both** provisioning and execution, so a session's
installs and its interpreter run are one atomic critical section — a build123d
install can no longer interleave with another part's `import cadquery`. The lock
order (v-env lock, then the conda global install lock) matches `once()`/`ensure`,
so it cannot deadlock. `sandbox_versions.py` gains a comment cross-referencing the
race and the fix.

## Validation

- Fresh-sandbox reproduction (`PC_INTERNAL_STATE_DIR` pointed at a clean dir): all
  cadquery part conversions pass, and the runtime does not deadlock (many
  sandbox-backed tests ran cleanly before/after).
- The intermittent race is best exercised by CI's fresh, concurrent sandboxes, so
  this PR's CI is the authoritative test — watch the `Examples`/cadquery-conversion
  jobs go green consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
