### PR TITLE
fix(sandbox): stop a single part from downgrading a package's shared CAD stack

### DIFF
--- a/partcad/src/partcad/part_factory_sdf.py
+++ b/partcad/src/partcad/part_factory_sdf.py
@@ -2,6 +2,7 @@ import os
 
 from .part_factory_python import PartFactoryPython
 from . import logging as pc_logging
+from . import sandbox_versions
 from . import wrapper
 from . import transform
 from . import shape_envelope
@@ -52,20 +53,31 @@ class PartFactorySdf(PartFactoryPython):
             request["label"] = part.name
             request_serialized = shape_envelope.serialize(request)
 
+            # The versions come from sandbox_versions, like every other factory's.
+            # They used to be pinned here to a generation of their own
+            # (cadquery-ocp 7.7.2, ocp-tessellate 3.0.9, build123d 0.8.0), which
+            # downgraded the CAD stack for every other part sharing this
+            # package's v-env - a CadQuery part rendered after an SDF one then
+            # died on OCP 7.7 with "type object 'OCP.TopoDS.TopoDS' has no
+            # attribute 'Vertex'". wrapper_sdf.py itself needs only sdf, numpy,
+            # OCP and ocp-tessellate; build123d was never imported by it.
             await self.runtime.ensure_async(
                 "sdf-fork",
                 session=self.session,
             )
             await self.runtime.ensure_async(
-                "cadquery-ocp==7.7.2",
+                sandbox_versions.NUMPY,
                 session=self.session,
             )
             await self.runtime.ensure_async(
-                "ocp-tessellate==3.0.9",
+                sandbox_versions.OCP_TESSELLATE,
                 session=self.session,
             )
+            # Last, by the convention every install list here follows: it undoes
+            # any novtk OCP a build123d install elsewhere in this v-env left
+            # behind (see sandbox_versions.GUARD_INVALIDATED_BY).
             await self.runtime.ensure_async(
-                "build123d==0.8.0",
+                sandbox_versions.CADQUERY_OCP,
                 session=self.session,
             )
 

--- a/partcad/src/partcad/runtime_python.py
+++ b/partcad/src/partcad/runtime_python.py
@@ -173,6 +173,10 @@ class PythonRuntime(runtime.Runtime):
         self.lock = threading.RLock()
         self.tls = threading.local()
 
+        # Requirements already reported as superseded by the pinned CAD stack,
+        # so the warning is emitted once per runtime instead of once per part.
+        self.superseded_requirements = set()
+
         # The path to the Python executable
         self.exec_path = None
         # The name of the Python executable to search for in bin folders
@@ -647,7 +651,32 @@ class PythonRuntime(runtime.Runtime):
         self.once()
         self.ensure_onced(python_package, session=session, path=path, force=force)
 
+    def reconcile_requirement(self, python_package):
+        """Hold the CAD stack in a sandbox to the versions PartCAD pins.
+
+        Every part of a package shares one session v-env, so a single part that
+        asks for its own version of cadquery-ocp, build123d, cadquery,
+        ocp-tessellate, ocpsvg or nlopt downgrades that stack under all the
+        others: the next part to run then dies inside its wrapper with an
+        ImportError or AttributeError that names neither the offending package
+        nor the version that caused it (see sandbox_versions.PINNED_REQUIREMENTS).
+
+        Substituting the pinned version keeps the sandbox coherent, and the
+        warning - once per runtime, not once per part - says what was overridden
+        so a package that genuinely needs another version is not left guessing.
+        """
+        python_package, superseded = sandbox_versions.reconcile_requirement(python_package)
+        if superseded is not None and superseded not in self.superseded_requirements:
+            self.superseded_requirements.add(superseded)
+            pc_logging.warning(
+                "Installing '%s' instead of '%s': PartCAD pins the CAD stack across a sandbox, "
+                "and mixing versions of it breaks the other parts that share the same environment."
+                % (python_package, superseded)
+            )
+        return python_package
+
     def ensure_onced(self, python_package, session=None, path=None, force=False):
+        python_package = self.reconcile_requirement(python_package)
         if path is None:
             path = self.path
 
@@ -688,6 +717,7 @@ class PythonRuntime(runtime.Runtime):
                 invalidate_dependent_guards(path, python_package)
 
     def ensure_onced_locked(self, python_package, session=None, path=None, force=False):
+        python_package = self.reconcile_requirement(python_package)
         if path is None:
             path = self.path
 
@@ -729,6 +759,7 @@ class PythonRuntime(runtime.Runtime):
         await self.ensure_async_onced(python_package, session=session, path=path, force=force)
 
     async def ensure_async_onced(self, python_package, session=None, path=None, force=False):
+        python_package = self.reconcile_requirement(python_package)
         if path is None:
             path = self.path
 
@@ -770,6 +801,7 @@ class PythonRuntime(runtime.Runtime):
                 invalidate_dependent_guards(path, python_package)
 
     async def ensure_async_onced_locked(self, python_package, session=None, path=None, force=False):
+        python_package = self.reconcile_requirement(python_package)
         if path is None:
             path = self.path
 

--- a/partcad/src/partcad/sandbox_versions.py
+++ b/partcad/src/partcad/sandbox_versions.py
@@ -93,6 +93,62 @@ GUARD_INVALIDATED_BY = {
     BUILD123D: (CADQUERY_OCP,),
 }
 
+# The CAD stack this module pins, keyed by distribution name. These packages are
+# a single, co-dependent generation: 'cadquery' 2.8 calls OCP 7.9 APIs that OCP
+# 7.7 does not have ("type object 'OCP.TopoDS.TopoDS' has no attribute 'Vertex'"),
+# 'ocp-tessellate' tracks the same generation, and build123d/cadquery-ocp write
+# the same native module. Installing any one of them at a different version
+# breaks the others.
+#
+# That matters because a *session* v-env is shared by every part of a package.
+# A single part asking for its own version of one of these (part_factory_sdf.py
+# used to pin cadquery-ocp==7.7.2, ocp-tessellate==3.0.9 and build123d==0.8.0)
+# silently downgraded the stack under every other part in the same package, and
+# their renders then failed with errors that named neither the package nor the
+# part that caused it. reconcile_requirement() below makes that impossible.
+PINNED_REQUIREMENTS = (
+    CADQUERY_OCP,
+    OCPSVG,
+    BUILD123D,
+    CADQUERY,
+    OCP_TESSELLATE,
+    NLOPT,
+)
+
+
+def distribution_name(requirement: str) -> str:
+    """The distribution a requirement string names, normalized per PEP 503.
+
+    Only what this module needs: a bare name optionally followed by extras, a
+    version specifier or an environment marker. URLs and paths are returned
+    unchanged (lowercased), which is enough for them to miss every lookup.
+    """
+    name = requirement.strip()
+    for separator in ("[", "=", "<", ">", "!", "~", ";", " ", "@"):
+        name = name.split(separator, 1)[0]
+    return name.strip().replace("_", "-").lower()
+
+
+# Built once: distribution name -> the requirement this module pins for it.
+_PINNED_BY_DISTRIBUTION = {distribution_name(requirement): requirement for requirement in PINNED_REQUIREMENTS}
+
+
+def reconcile_requirement(requirement: str) -> tuple[str, str | None]:
+    """Force a CAD-stack requirement to the version this module pins.
+
+    Returns '(requirement_to_install, superseded_requirement)'. The second value
+    is the caller's original requirement when it was overridden, and None when
+    the requirement was left alone - callers use it to report the substitution.
+
+    Anything outside PINNED_REQUIREMENTS is returned untouched: a package is free
+    to install whatever else it needs into its sandbox.
+    """
+    pinned = _PINNED_BY_DISTRIBUTION.get(distribution_name(requirement))
+    if pinned is None or requirement.strip() == pinned:
+        return requirement, None
+    return pinned, requirement
+
+
 # What a sandbox gets when the package does not ask for a specific interpreter.
 # One step ahead of the minimum PartCAD itself supports.
 DEFAULT_PYTHON_VERSION = "3.11"

--- a/partcad/tests/unit/test_runtime_python_deps.py
+++ b/partcad/tests/unit/test_runtime_python_deps.py
@@ -261,3 +261,66 @@ def test_ensure_zstd_installs_nothing_where_the_stdlib_has_it(tmp_path, monkeypa
     asyncio.run(PythonRuntime.ensure_zstd_onced_locked_async(runtime))
 
     assert requested == []
+
+
+def test_reconcile_requirement_forces_the_pinned_cad_stack():
+    """A part asking for its own CAD version gets the sandbox-wide pin instead.
+
+    These three are the versions part_factory_sdf.py used to pin. Installed into
+    a session v-env they downgraded the stack under every other part of the same
+    package, and the next CadQuery render died on OCP 7.7 with "type object
+    'OCP.TopoDS.TopoDS' has no attribute 'Vertex'".
+    """
+    for stale, pinned in [
+        ("cadquery-ocp==7.7.2", sandbox_versions.CADQUERY_OCP),
+        ("ocp-tessellate==3.0.9", sandbox_versions.OCP_TESSELLATE),
+        ("build123d==0.8.0", sandbox_versions.BUILD123D),
+    ]:
+        assert sandbox_versions.reconcile_requirement(stale) == (pinned, stale)
+
+
+def test_reconcile_requirement_normalizes_the_distribution_name():
+    """PEP 503 normalization, so an underscore or capitals cannot slip past."""
+    for spelling in ["cadquery_ocp==7.7.2", "CadQuery-OCP==7.7.2", "build123d[ocp]==0.8.0"]:
+        reconciled, superseded = sandbox_versions.reconcile_requirement(spelling)
+        assert superseded == spelling
+        assert reconciled in (sandbox_versions.CADQUERY_OCP, sandbox_versions.BUILD123D)
+
+
+def test_reconcile_requirement_leaves_everything_else_alone():
+    """Only the co-dependent CAD stack is pinned; other packages are the package's own business."""
+    for untouched in ["sdf-fork", "numpy>=2.2,<3", "requests", sandbox_versions.CADQUERY_OCP]:
+        assert sandbox_versions.reconcile_requirement(untouched) == (untouched, None)
+
+
+def test_runtime_reconciles_a_requirement_and_warns_once(tmp_path, monkeypatch):
+    """The substitution is visible, but does not repeat for every part."""
+    runtime = _bare_runtime(tmp_path / "sandbox")
+    runtime.superseded_requirements = set()
+    recorded = _record_warnings(monkeypatch)
+
+    assert runtime.reconcile_requirement("cadquery-ocp==7.7.2") == sandbox_versions.CADQUERY_OCP
+    assert runtime.reconcile_requirement("cadquery-ocp==7.7.2") == sandbox_versions.CADQUERY_OCP
+
+    assert len(recorded) == 1
+    assert "cadquery-ocp==7.7.2" in recorded[0]
+    assert sandbox_versions.CADQUERY_OCP in recorded[0]
+
+
+def test_no_factory_pins_its_own_version_of_the_shared_cad_stack():
+    """Regression guard for the bug this file's reconciliation exists to prevent.
+
+    A session v-env is shared by every part of a package, so a factory that
+    hardcodes its own version of a pinned distribution corrupts that environment
+    for the other parts. Everything must go through sandbox_versions.
+    """
+    pinned_names = {sandbox_versions.distribution_name(req) for req in sandbox_versions.PINNED_REQUIREMENTS}
+    src = pathlib.Path(__file__).parent.parent.parent / "src" / "partcad"
+    offenders = []
+    for path in sorted(src.rglob("*.py")):
+        if path.name == "sandbox_versions.py":
+            continue
+        for literal in re.findall(r"""["']([A-Za-z0-9_.\-\[\]]+==[^"']+)["']""", path.read_text()):
+            if sandbox_versions.distribution_name(literal) in pinned_names:
+                offenders.append("%s: %s" % (path.name, literal))
+    assert offenders == [], offenders


### PR DESCRIPTION
## Summary

Fixes the intermittent `Examples` failures where CadQuery parts died with

```
AttributeError: type object 'OCP.TopoDS.TopoDS' has no attribute 'Vertex'. Did you mean: 'Vertex_s'?
```

on Linux, Windows **and** macOS — the last of the cross-platform CI flakiness.

## Root cause: one part downgrading the whole package's CAD stack

`part_factory_sdf.py` pinned a CAD generation of its own and installed it with
`session=self.session`:

```python
"cadquery-ocp==7.7.2"      # pinned everywhere else: 7.9.3.1.1
"ocp-tessellate==3.0.9"    # pinned everywhere else: 3.4.1
"build123d==0.8.0"         # pinned everywhere else: 0.11.1
```

A **session v-env is shared by every part of a package**, so any package containing an
SDF part had its CAD stack downgraded underneath the *other* parts. `cadquery` 2.8 then
called OCP 7.9 APIs against an OCP 7.7 module and failed — with an error naming neither
the SDF part nor the version that caused it.

It looked intermittent only because `--threads-max 4` decided whether the SDF part landed
before or after the others. #487 (serializing a v-env's installs and its run) narrowed the
timing window but could not fix a version downgrade.

Reproduced from scratch (`PC_INTERNAL_STATE_DIR` at a clean dir, rendering
`feature_convert_part` — which has SDF, CadQuery **and** build123d parts — with
`--threads-max 4`). The v-env came up as:

```
build123d 0.8.0 · cadquery 2.8.0 · cadquery-ocp 7.7.2 · cadquery-ocp-proxy 7.9.3.1.1 · ocp-tessellate 3.0.9
→ AttributeError: 'OCP.TopoDS.TopoDS' has no attribute 'Vertex'
```

## Fix

**1. The offender.** `part_factory_sdf.py` takes its versions from `sandbox_versions` like
every other factory, ends its install list with `CADQUERY_OCP` per the existing convention,
and drops `build123d` entirely — `wrapper_sdf.py` imports only `sdf`, `numpy`, `OCP` and
`ocp_tessellate`, and never imported build123d.

**2. A guard so this cannot recur.** `sandbox_versions` gains `PINNED_REQUIREMENTS` (the
co-dependent CAD stack: cadquery-ocp, ocpsvg, build123d, cadquery, ocp-tessellate, nlopt)
and `reconcile_requirement()`, wired into all four `PythonRuntime.ensure_*` entry points.
A request for one of those distributions at any other version installs the pinned version
instead and warns once per runtime naming what was superseded. No factory, plugin, or
package `pythonRequirements` can silently corrupt a shared sandbox again. Distribution
names are normalized per PEP 503, so `cadquery_ocp==…`, `CadQuery-OCP==…` and
`build123d[ocp]==…` are all caught.

## Validation

- **After the fix**, the same from-scratch concurrent run yields a coherent v-env
  (`cadquery-ocp 7.9.3.1.1`, `ocp-tessellate 3.4.1`, `vtk 9.6.2`, no stale pins) and every
  part renders, SDF included.
- `pytest partcad partcad-cli`: **457 passed, 21 skipped**.
- New tests cover the substitution, PEP 503 normalization, warn-once behaviour, and a
  **regression guard that fails if any factory ever re-pins a shared-stack distribution** —
  it would have caught this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
