### PR TITLE
docs: refresh the stale Python version numbers

### DIFF
--- a/dev-tools/pyinstaller/README.md
+++ b/dev-tools/pyinstaller/README.md
@@ -8,7 +8,7 @@ with [`install.sh`](../../install.sh) and never see Python.
 | | wheels | standalone bundle |
 | --- | --- | --- |
 | Install | `pip install -U partcad-cli` | `curl -fsSL .../install.sh \| sh` |
-| Needs Python | yes, 3.10-3.12 | no |
+| Needs Python | yes, 3.10-3.14 | no |
 | Size | ~15MB plus whatever pip resolves | ~875MB unpacked, ~290MB compressed (Linux, OpenSCAD included) |
 | Optional extras (`ai`, `lint`) | installed on demand | always included |
 | Importable as a library | yes | no, it is only the CLI |
@@ -61,9 +61,13 @@ The results land in `dist/standalone/`: the `partcad/` bundle, an archive named
 with `install.sh`, which derives the same name from `uname`.
 
 The bundle embeds the interpreter it was built with, so `PYTHON` decides the Python version users end up
-running. CI builds with 3.11, and 3.11 or 3.12 is required: PartCAD itself still supports 3.10, but
-`ocp_vscode` (what `pc inspect` hands shapes to) does not import there, and a dependency that cannot be
-imported cannot be frozen. `build.sh` checks that before it builds and says which import failed.
+running. CI builds with 3.14, the newest version PartCAD supports (`requires-python = ">=3.10,<3.15"`) and
+deliberately ahead of the 3.13 the wheels publish from: a standalone user cannot change the interpreter after
+the fact the way someone installing the wheels can, so shipping the oldest supported one would leave them on it
+for the life of the bundle. Nothing older is exercised. `ocp_vscode` (what `pc inspect` hands shapes to) long
+required 3.11 or newer, which is why the floor used to be documented as 3.11; it and its dependencies now all
+declare `>=3.10`, but only the version CI builds with is tested. A dependency that cannot be imported cannot be
+frozen, so `build.sh` imports them all before it builds and says which import failed.
 
 ## What the frozen bundle changes, and what it does not
 

--- a/dev-tools/pyinstaller/build.sh
+++ b/dev-tools/pyinstaller/build.sh
@@ -270,7 +270,7 @@ import sys
 REQUIRED = {
     "OCP": "the geometry kernel",
     "build123d": "the geometry kernel",
-    "ocp_vscode": "`pc inspect` (needs Python 3.11 or newer)",
+    "ocp_vscode": "`pc inspect`",
     "ruff.__main__": "`pc lint` of Python files",
 }
 

--- a/dev-tools/pyinstaller/partcad.spec
+++ b/dev-tools/pyinstaller/partcad.spec
@@ -144,10 +144,12 @@ add_package("ocpsvg")
 # ordinary extension modules.)
 add_package("lib3mf")
 
-# zstd for the BREP payloads of the wrapper protocol and the shape cache. The
-# bundle is frozen with 3.11 (see build.sh), which has no 'compression.zstd', so
-# the backport is what it actually imports. It lives under the 'backports'
-# namespace package, which PyInstaller does not follow into on its own.
+# zstd for the BREP payloads of the wrapper protocol and the shape cache. CI
+# freezes with 3.14 (see build-standalone.yml), whose standard library carries
+# 'compression.zstd', so this collects nothing there. On an older interpreter
+# PartCAD imports the backport of that module instead, and it lives under the
+# 'backports' namespace package, which PyInstaller does not follow into on its
+# own.
 if sys.version_info < (3, 14):
     add_package("backports.zstd")
 

--- a/partcad-ide-vscode/README.md
+++ b/partcad-ide-vscode/README.md
@@ -80,7 +80,7 @@ It's easier to test some parts of the robot like `link-lower-arm` or `link-base`
 ### Failed to load PartCAD: \_nlopt
 
 If you see the above error message then you are probably using Windows and not using Conda.
-Please, switch to a Python environment created with Conda and Python >=3.10 and <=3.11.
+Please, switch to a Python environment created with Conda and Python >=3.10 and <3.15.
 
 ## More documentation
 


### PR DESCRIPTION
## Ground truth

Everything below was checked against the authoritative sources rather than against each other:

| fact | source |
| --- | --- |
| supported range `>=3.10,<3.15` | `partcad/pyproject.toml`, `partcad-cli/pyproject.toml` (classifiers agree: 3.10–3.14) |
| standalone bundle frozen with **3.14** | `.github/workflows/build-standalone.yml` |
| wheels published from **3.13** | `.github/workflows/deploy.yml` |
| Read the Docs builds on **3.13** | `.readthedocs.yaml` |
| VS Code extension accepts **3.10 and above** | `checkVersion()` in `partcad-ide-vscode/src/common/python.ts`, and the `(>=3.10)` viewsWelcome string in `package.json` |

## What was stale

**`dev-tools/pyinstaller/README.md`** — the comparison table said the wheels need "3.10-3.12", and the
interpreter paragraph said CI freezes with 3.11 and that "3.11 or 3.12 is required". CI has frozen with 3.14
for a while.

The paragraph's *reason* for the 3.11 floor was also out of date: it said `ocp_vscode` does not import on 3.10.
`ocp_vscode` 4.0.1 declares `>=3.10`, and so does every dependency it pulls — `ocp-tessellate` 3.4.1,
`ipykernel` 7.3.0, `pillow` 12.3.0, `threejs-materials` 1.2.3, `pygltflib` (`>=3.6`). I did **not** turn that
into a claim that 3.10 works: declared metadata is not the same as a tested build, and verifying importability
needs a real 3.10 environment with OCP in it. The text now states what CI builds with and that nothing older is
exercised, and keeps the history in one clause so the next person does not have to re-derive it.

**`dev-tools/pyinstaller/partcad.spec`** — the zstd comment claimed the bundle "is frozen with 3.11 … which has
no `compression.zstd`, so the backport is what it actually imports". The `if sys.version_info < (3, 14)` guard
immediately below it says otherwise: at the version CI actually uses, the branch does not run and the backport
is not collected at all.

**`dev-tools/pyinstaller/build.sh`** — the pre-flight annotated `ocp_vscode` as "needs Python 3.11 or newer" in
the message printed when its import fails. Dropped rather than restated to a different number, for the reason
above: the interpreter version is no longer the distinguishing fact about that import.

**`partcad-ide-vscode/README.md`** — told users hitting the `_nlopt` load failure to switch to a Conda
environment with Python ">=3.10 and <=3.11". The extension accepts 3.10 and above, so the upper bound was
simply wrong; it now states the range PartCAD supports.

## What I deliberately left alone

- `docs/source/tutorial.rst` — "Activate a Python environment (3.10 or above)." 3.10 is still the floor, so
  this is correct.
- `docs/source/troubleshooting.rst` — quotes the extension's own `"No Python (>= 3.10) installed"` message.
  Correct, and it is a quotation of a UI string rather than a claim of its own.
- `docs/braindump.md` — `conda create … python=3.10` in a testbed recipe. 3.10 is still supported.

The first two matter beyond being correct: both strings appear as `msgid`s in the de/es/ru/zh_CN catalogs under
`docs/source/locales/`. Editing either would mark the existing translations `#, fuzzy` (see
`docs/update-translations.sh`) and drop four languages back to English for no factual gain. None of the four
files this PR does touch is under `docs/source/`, so no catalog is affected and `update-translations.sh` does
not need to run.

## Validation

- Swept the repository for `3.1[0-9]` across `*.md`, `*.rst`, `*.sh`, `*.spec`, `*.toml` and `*.cfg`; every
  remaining hit is either a source of truth (the `pyproject.toml` constraints and classifiers), an accurate
  comment (`build.sh` on PyInstaller 6.15 and on `compression.zstd`; the `pyproject.toml` note on Sphinx and
  Read the Docs, which matches `.readthedocs.yaml`), or one of the three intentional keeps above.
- `pre-commit run --config dev-tools/pre-commit-config.yaml` passes; `partcad.spec` still parses as Python and
  `bash -n` is clean on `build.sh`.
- Documentation and comments only — no behavior change, and the `Standalone` workflow's path filter still
  triggers on `dev-tools/pyinstaller/**`, so the bundle gets rebuilt on this PR anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
