### PR TITLE
fix(sandbox): close two holes in the pinned-CAD-stack guard (follow-up to #491)

### DIFF
--- a/partcad/src/partcad/sandbox_versions.py
+++ b/partcad/src/partcad/sandbox_versions.py
@@ -13,6 +13,8 @@ OCP a shared sandbox gets -- a disagreement that surfaces as a native crash
 with no Python traceback at all (see runtime_python.PIP_CONSTRAINTS).
 """
 
+import re
+
 # 'cadquery-ocp' and the 'cadquery-ocp-novtk' that build123d 0.11 depends on
 # are NOT alternatives pip knows about: they are separate distributions that
 # both write the very same OCP native module, so whichever pip installs last
@@ -122,11 +124,23 @@ def distribution_name(requirement: str) -> str:
     Only what this module needs: a bare name optionally followed by extras, a
     version specifier or an environment marker. URLs and paths are returned
     unchanged (lowercased), which is enough for them to miss every lookup.
+
+    The normalization is the full PEP 503 rule - lowercase, with every run of
+    '.', '-' and '_' collapsed to a single '-' - because pip accepts all of those
+    spellings for the same distribution. Anything less lets 'cadquery.ocp==7.7.2'
+    or 'cadquery--ocp==7.7.2' name the pinned CAD stack while slipping past the
+    lookup below, which is exactly what this guard exists to prevent.
     """
     name = requirement.strip()
     for separator in ("[", "=", "<", ">", "!", "~", ";", " ", "@"):
         name = name.split(separator, 1)[0]
-    return name.strip().replace("_", "-").lower()
+    return re.sub(r"[-_.]+", "-", name.strip()).lower()
+
+
+def _split_marker(requirement: str) -> tuple[str, str | None]:
+    """Split a requirement into its body and its environment marker, if any."""
+    body, separator, marker = requirement.partition(";")
+    return body.strip(), (marker.strip() if separator else None)
 
 
 # Built once: distribution name -> the requirement this module pins for it.
@@ -140,13 +154,21 @@ def reconcile_requirement(requirement: str) -> tuple[str, str | None]:
     is the caller's original requirement when it was overridden, and None when
     the requirement was left alone - callers use it to report the substitution.
 
+    An environment marker is carried over onto the pinned requirement: the caller
+    asked for the package only under that condition, and dropping the marker
+    would install it unconditionally instead. Only the version is overridden.
+
     Anything outside PINNED_REQUIREMENTS is returned untouched: a package is free
     to install whatever else it needs into its sandbox.
     """
-    pinned = _PINNED_BY_DISTRIBUTION.get(distribution_name(requirement))
-    if pinned is None or requirement.strip() == pinned:
+    body, marker = _split_marker(requirement)
+    pinned = _PINNED_BY_DISTRIBUTION.get(distribution_name(body))
+    if pinned is None:
         return requirement, None
-    return pinned, requirement
+    reconciled = pinned if marker is None else "%s; %s" % (pinned, marker)
+    if reconciled == requirement.strip():
+        return requirement, None
+    return reconciled, requirement
 
 
 # What a sandbox gets when the package does not ask for a specific interpreter.

--- a/partcad/tests/unit/test_runtime_python_deps.py
+++ b/partcad/tests/unit/test_runtime_python_deps.py
@@ -280,11 +280,42 @@ def test_reconcile_requirement_forces_the_pinned_cad_stack():
 
 
 def test_reconcile_requirement_normalizes_the_distribution_name():
-    """PEP 503 normalization, so an underscore or capitals cannot slip past."""
-    for spelling in ["cadquery_ocp==7.7.2", "CadQuery-OCP==7.7.2", "build123d[ocp]==0.8.0"]:
-        reconciled, superseded = sandbox_versions.reconcile_requirement(spelling)
-        assert superseded == spelling
-        assert reconciled in (sandbox_versions.CADQUERY_OCP, sandbox_versions.BUILD123D)
+    """Full PEP 503 normalization, so no spelling of a pinned name slips past.
+
+    pip accepts '.', '-' and '_' interchangeably and collapses runs of them, so
+    anything less than the whole rule leaves a way to name the pinned CAD stack
+    and still get an arbitrary version installed.
+    """
+    for spelling, expected in [
+        ("cadquery_ocp==7.7.2", sandbox_versions.CADQUERY_OCP),
+        ("CadQuery-OCP==7.7.2", sandbox_versions.CADQUERY_OCP),
+        ("cadquery.ocp==7.7.2", sandbox_versions.CADQUERY_OCP),
+        ("cadquery--ocp==7.7.2", sandbox_versions.CADQUERY_OCP),
+        ("cadquery_.-ocp==7.7.2", sandbox_versions.CADQUERY_OCP),
+        ("OCP_Tessellate==3.0.9", sandbox_versions.OCP_TESSELLATE),
+        ("build123d[ocp]==0.8.0", sandbox_versions.BUILD123D),
+    ]:
+        assert sandbox_versions.reconcile_requirement(spelling) == (expected, spelling)
+
+
+def test_reconcile_requirement_keeps_the_environment_marker():
+    """Only the version is overridden; the caller's condition is preserved.
+
+    Dropping the marker would install the package unconditionally, which is not
+    what a requirement guarded by one asked for.
+    """
+    marked = 'build123d==0.8.0; sys_platform == "linux"'
+    reconciled, superseded = sandbox_versions.reconcile_requirement(marked)
+
+    assert superseded == marked
+    assert reconciled == '%s; sys_platform == "linux"' % sandbox_versions.BUILD123D
+
+
+def test_reconcile_requirement_leaves_a_pinned_requirement_with_a_marker_alone():
+    """Already at the pinned version, marker and all -> nothing to report."""
+    already = '%s; sys_platform == "linux"' % sandbox_versions.BUILD123D
+
+    assert sandbox_versions.reconcile_requirement(already) == (already, None)
 
 
 def test_reconcile_requirement_leaves_everything_else_alone():


### PR DESCRIPTION
## Summary

Follow-up to #491, addressing its review. Both findings were real holes in the guard
#491 introduced — the guard could be bypassed, and it changed install semantics.

## 1. PEP 503 normalization was incomplete (the guard was bypassable)

`distribution_name()` collapsed `_` but not `.`, and collapsed no runs of either. pip
accepts `.`, `-` and `_` interchangeably for the same distribution, so the guard could be
walked straight past by spelling the name differently — the exact downgrade #491 exists to
prevent was still reachable:

| spelling | caught before | caught now |
|---|---|---|
| `cadquery_ocp==7.7.2` | ✅ | ✅ |
| `cadquery.ocp==7.7.2` | ❌ | ✅ |
| `cadquery--ocp==7.7.2` | ❌ | ✅ |
| `CadQuery.OCP==7.7.2` | ❌ | ✅ |

Now applies the whole rule: lowercase, with every run of `.`, `-`, `_` collapsed to a
single `-`.

## 2. Environment markers were dropped (install semantics changed)

`reconcile_requirement()` returned the pinned requirement verbatim, discarding any marker
the caller attached:

```
build123d==0.8.0; sys_platform == "linux"   →   build123d==0.11.1
```

which installs it on every platform, including the ones the caller deliberately excluded.
The marker is now carried over and only the version is overridden:

```
build123d==0.8.0; sys_platform == "linux"   →   build123d==0.11.1; sys_platform == "linux"
```

A requirement already at the pinned version — marker included — is left untouched and
reported as unchanged, so it produces no spurious warning.

## 3. Test strictness

The normalization test accepted *any* pinned requirement (`reconciled in (...)`), so a
`cadquery-ocp` spelling mapping to `build123d` would have passed. It now asserts the exact
expected pin per spelling, and covers dotted names, repeated/mixed separators, marker
preservation, and the already-pinned-with-marker case.

## Validation

- `pytest partcad partcad-cli`: **459 passed, 21 skipped**.
- Verified directly against the pre-fix implementation that the three dotted/doubled
  spellings above bypassed the guard before this change and are caught after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
